### PR TITLE
flake: add Security apple framework

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -176,7 +176,8 @@
           [lld_13 cargo-flamegraph rust-analyzer]
           ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) pkgs.cargo-tarpaulin)
           ++ (lib.optional stdenv.isLinux pkgs.lldb)
-          ++ (lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.CoreFoundation);
+          ++ (lib.optional stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks;
+            [CoreFoundation Security]));
         shellHook = ''
           export HELIX_RUNTIME="$PWD/runtime"
           export RUST_BACKTRACE="1"


### PR DESCRIPTION
I noticed the Nix development shell defined in the helix flake couldn't compile `steel-core` on MacOS without the Security framework, so I have added it.

This was the only change I needed to then follow the rest of the setup in `STEEL.md`, so I'm happy to get started now!