### PR TITLE
Optionally load init.scm and helix.scm from .helix/

### DIFF
--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -2,7 +2,7 @@ use arc_swap::ArcSwapAny;
 use helix_core::{
     diagnostic::Severity,
     extensions::steel_implementations::{rope_module, SteelRopeSlice},
-    graphemes,
+    find_workspace, graphemes,
     shellwords::Shellwords,
     syntax::{AutoPairConfig, SoftWrap},
     Range, Selection, Tendril,
@@ -1198,12 +1198,25 @@ pub fn is_keymap(keymap: SteelVal) -> bool {
     }
 }
 
+fn local_config_exists() -> bool {
+    let local_helix = find_workspace().0.join(".helix");
+    local_helix.join("helix.scm").exists() && local_helix.join("init.scm").exists()
+}
+
+fn preferred_config_path(file_name: &str) -> PathBuf {
+    if local_config_exists() {
+        find_workspace().0.join(".helix").join(file_name)
+    } else {
+        helix_loader::config_dir().join(file_name)
+    }
+}
+
 pub fn helix_module_file() -> PathBuf {
-    helix_loader::config_dir().join("helix.scm")
+    preferred_config_path("helix.scm")
 }
 
 pub fn steel_init_file() -> PathBuf {
-    helix_loader::config_dir().join("init.scm")
+    preferred_config_path("init.scm")
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
First, thanks for your work on this fork.  I'm pretty excited about using it to do unnatural things to helix 😈 

This PR makes it easy to switch in/out of a helix plugin dev environment.

Suppose I'm writing a helix plugin and making a terrible mess in `helix.scm` and `init.scm`, and then I get paged for a work thing.  I want to be able to quickly transition out of my mess, handle the page with my normal helix configs, and then transition back into the mess and continue development. I'm playing with the idea of doing this by `cd`-ing in/out of the plugin project directory.

This PR changes helix so that it will load `helix.scm` and `init.scm` in a way that resembles how it loads `languages.toml`--that is, it will read files if they both exist in `./.helix`.  Otherwise, it will consult ~/.config/helix (as it did before).  This dependency on the CWD makes it possible to achieve the environment-switching that I'm shooting for.

I am a rust novice, and not familiar with developing helix. If there's a better way to do this, I'm all ears.

(Sorry for the duplicate re: https://github.com/mattwparas/helix/pull/4, I made a branch naming mistake)