### PR TITLE
Add a flake output for the helix cogs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,25 @@
           # filter out unnecessary paths
           filter = ignorePaths;
         };
+
+      helix-cogs = craneLibStable.buildPackage (commonArgs // {
+        pname = "helix-cogs";
+        version = "0.1.0";
+        cargoArtifacts = craneLibStable.buildDepsOnly commonArgs;
+
+        buildPhase = ''
+          export HOME=$PWD/build_home  # code-gen will write files relative to $HOME
+          cargoBuildLog=$(mktemp cargoBuildLogXXXX.json)
+          cargo run --package xtask -- code-gen --message-format json-render-diagnostics >"$cargoBuildLog"
+        '';
+
+        postInstall = ''
+          mkdir -p $out/cogs
+          cp -r build_home/.config/helix/* "$out/cogs"
+        '';
+
+      });
+
       makeOverridableHelix = old: config: let
         grammars = pkgs.callPackage ./grammars.nix config;
         runtimeDir = pkgs.runCommand "helix-runtime" {} ''
@@ -144,6 +163,7 @@
             '';
           });
         helix = makeOverridableHelix self.packages.${system}.helix-unwrapped {};
+        helix-cogs = helix-cogs;
         default = self.packages.${system}.helix;
       };
 

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -871,7 +871,10 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
         let mut target_directory = helix_runtime_search_path();
 
         if !target_directory.exists() {
-            std::fs::create_dir(&target_directory).unwrap();
+            std::fs::create_dir_all(&target_directory).unwrap_or_else(|err| {
+                panic!("Failed to create directory {:?}: {}", target_directory, err)
+            });
+            eprintln!("Created directory: {:?}", target_directory);
         }
 
         target_directory.push("editor.scm");


### PR DESCRIPTION
You can already ask the flake to build helix for you, this PR adds the ability to build the helix cogs also:

```
❯ nix build .#helix-cogs
❯ ls result/cogs/helix
╭───┬─────────────────────────────────────┬──────┬─────────╮
│ # │                name                 │ type │  size   │
├───┼─────────────────────────────────────┼──────┼─────────┤
│ 0 │ result/cogs/helix/commands.scm      │ file │ 14.8 KB │
│ 1 │ result/cogs/helix/misc.scm          │ file │  1.8 KB │
│ 2 │ result/cogs/helix/static.scm        │ file │ 42.5 KB │
│ 3 │ result/cogs/helix/configuration.scm │ file │  6.5 KB │
│ 4 │ result/cogs/helix/editor.scm        │ file │  1.8 KB │
╰───┴─────────────────────────────────────┴──────┴─────────╯

```

By default, `cargo xtask code-gen` modifies `~/.config`.   I find this easy to lose track of.  For instance, I had plugins working on one machine and not on the other and I was scratching my head about what was different between those machines.  

This change makes it easy to just get the cogs without modifying my config, which is handy for creating dev environments which are isolated from the rest of my system (like [this one](https://github.com/MatrixManAtYrService/helix-plugin-env), which is a work in progress).