### PR TITLE
Optionally load init.scm and helix.scm from env var

### DIFF
--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -1416,7 +1416,9 @@ fn local_config_exists() -> bool {
 }
 
 fn preferred_config_path(file_name: &str) -> PathBuf {
-    if local_config_exists() {
+    if let Ok(steel_config_dir) = std::env::var("HELIX_STEEL_CONFIG") {
+        PathBuf::from(steel_config_dir).join(file_name)
+    } else if local_config_exists() {
         find_workspace().0.join(".helix").join(file_name)
     } else {
         helix_loader::config_dir().join(file_name)


### PR DESCRIPTION
Hi!

I'm trying to package things properly in nix, and currently I'm facing a small issue: it is currently not possible to have a pure configuration, but it can be solve easily by adding the possibility to load both `helix.scm` and `init.scm` from an env variable. I chose `HELIX_STEEL_CONFIG`, but I can change it if you think that an other one may be better suited.

Thanks for your incredible work!
