### PR TITLE
Generate language server primitives in helix-cogs Nix output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,15 +76,17 @@
 
         buildPhase = ''
           export HOME=$PWD/build_home  # code-gen will write files relative to $HOME
+          export STEEL_LSP_HOME=$PWD/lsp_home  # required to generate primitives for language server
+          mkdir -p $STEEL_LSP_HOME
           cargoBuildLog=$(mktemp cargoBuildLogXXXX.json)
           cargo run --package xtask -- code-gen --message-format json-render-diagnostics >"$cargoBuildLog"
         '';
 
         postInstall = ''
-          mkdir -p $out/cogs
+          mkdir -p $out/cogs $out/steel-language-server
           cp -r build_home/.config/helix/* "$out/cogs"
+          cp -r lsp_home/* "$out/steel-language-server"
         '';
-
       });
 
       makeOverridableHelix = old: config: let
@@ -161,7 +163,7 @@
             HELIX_NIX_BUILD_REV = self.rev or self.dirtyRev or null;
           });
         helix = makeOverridableHelix self.packages.${system}.helix-unwrapped {};
-        helix-cogs = helix-cogs;
+        inherit helix-cogs;
         default = self.packages.${system}.helix;
       };
 


### PR DESCRIPTION
This PR exposes the generated primitives for the language server to Nix users. As far as I can tell, this wasn't possible using the flake before - please let me know if I'm wong about that!

The original `cogs` directory remains unchanged, but a new `steel-language-server` directory is added to the `helix-cogs` output. Using Home Manager, a user could symlink that to `STEEL_LSP_HOME`, or even do something like this with a nested LSP home.
```nix
{ inputs, config, ... }: {
  xdg.dataFile.steel.source = inputs.helix.packages.${system}.helix-cogs;
  xdg.dataFile.steel.recursive = true;
  home.sessionVariables.STEEL_HOME = "${config.xdg.dataHome}/steel";
  home.sessionVariables.STEEL_LSP_HOME = "${config.xdg.dataHome}/steel/steel-language-server";
}
```

I'm open to changing this. I considered splitting this into two outputs, but found the simplicity of this much nicer since the output of the helix-cogs derivation is just files. Please let me know if you'd prefer a different structure or some renaming. As it is, I'm happy with this.