### PR TITLE
Get a register value using Steel

### DIFF
--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -1106,7 +1106,7 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
 {}
 (define ({} arg)
     (helix.{} *helix.cx* arg))
-    "#,
+"#,
                     name, docstring, name, name
                 ));
             }

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -1096,32 +1096,52 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
         template_function_arity_0("cx->cursor");
         template_function_arity_0("editor-focused-buffer-area");
 
-        let mut template_function_arity_1 = |name: &str| {
-            builtin_editor_command_module.push_str(&format!(
-                r#"
+        let mut template_function_arity_1 = |name: &str, doc: &str| {
+            if generate_sources {
+                let docstring = format_docstring(doc);
+                builtin_editor_command_module.push_str(&format!(
+                    r#"
 (provide {})
+;;@doc
+{}
 (define ({} arg)
     (helix.{} *helix.cx* arg))
-"#,
-                name, name, name
-            ));
+    "#,
+                    name, docstring, name, name
+                ));
+            }
         };
 
-        template_function_arity_1("editor->doc-id");
-        template_function_arity_1("editor-switch!");
-        template_function_arity_1("editor-set-focus!");
-        template_function_arity_1("editor-set-mode!");
-        template_function_arity_1("editor-doc-in-view?");
-        template_function_arity_1("set-scratch-buffer-name!");
-        template_function_arity_1("editor-doc-exists?");
-        template_function_arity_1("editor->text");
-        template_function_arity_1("editor-document->path");
-        template_function_arity_1("register->value");
+        template_function_arity_1("editor->doc-id", "Get the document from a given view");
+        template_function_arity_1("editor-switch!", "Open the document in a vertical split");
+        template_function_arity_1("editor-set-focus!", "Set focus on the view");
+        template_function_arity_1("editor-set-mode!", "Set the editor mode");
+        template_function_arity_1(
+            "editor-doc-in-view?",
+            "Check whether the current view contains a document",
+        );
+        template_function_arity_1(
+            "set-scratch-buffer-name!",
+            "Set the name of a scratch buffer",
+        );
+        template_function_arity_1("editor-doc-exists?", "Check if a document exists");
+        template_function_arity_1("editor->text", "Get the document text as a rope");
+        template_function_arity_1("editor-document->path", "Get the path to a document");
+        template_function_arity_1("register->value", "Get register value as a list of strings");
 
-        template_function_arity_1("set-editor-clip-top!");
-        template_function_arity_1("set-editor-clip-right!");
-        template_function_arity_1("set-editor-clip-left!");
-        template_function_arity_1("set-editor-clip-bottom!");
+        template_function_arity_1("set-editor-clip-top!", "Set the editor clipping at the top");
+        template_function_arity_1(
+            "set-editor-clip-right!",
+            "Set the editor clipping at the right",
+        );
+        template_function_arity_1(
+            "set-editor-clip-left!",
+            "Set the editor clipping at the left",
+        );
+        template_function_arity_1(
+            "set-editor-clip-bottom!",
+            "Set the editor clipping at the bottom",
+        );
 
         let mut template_function_arity_2 = |name: &str| {
             builtin_editor_command_module.push_str(&format!(

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -1035,6 +1035,7 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
     // Arity 1
     module.register_fn("editor->text", document_id_to_text);
     module.register_fn("editor-document->path", document_path);
+    module.register_fn("register->value", cx_register_value);
 
     module.register_fn("set-editor-clip-right!", |cx: &mut Context, right: u16| {
         cx.editor.editor_clipping.right = Some(right);
@@ -1112,6 +1113,7 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
         template_function_arity_1("editor-doc-exists?");
         template_function_arity_1("editor->text");
         template_function_arity_1("editor-document->path");
+        template_function_arity_1("register->value");
 
         template_function_arity_1("set-editor-clip-top!");
         template_function_arity_1("set-editor-clip-right!");
@@ -3067,6 +3069,15 @@ fn cx_is_document_in_view(cx: &mut Context, doc_id: DocumentId) -> Option<helix_
         .traverse()
         .find(|(_, v)| v.doc == doc_id)
         .map(|(id, _)| id)
+}
+
+fn cx_register_value(cx: &mut Context, name: char) -> Vec<String> {
+    let items = cx
+        .editor
+        .registers
+        .read(name, cx.editor)
+        .map_or(Vec::new(), |reg| reg.collect());
+    items.into_iter().map(|value| value.to_string()).collect()
 }
 
 fn cx_document_exists(cx: &mut Context, doc_id: DocumentId) -> bool {

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -1112,35 +1112,40 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
             }
         };
 
-        template_function_arity_1("editor->doc-id", "Get the document from a given view");
-        template_function_arity_1("editor-switch!", "Open the document in a vertical split");
-        template_function_arity_1("editor-set-focus!", "Set focus on the view");
-        template_function_arity_1("editor-set-mode!", "Set the editor mode");
+        template_function_arity_1("editor->doc-id", "Get the document from a given view.");
+        template_function_arity_1("editor-switch!", "Open the document in a vertical split.");
+        template_function_arity_1("editor-set-focus!", "Set focus on the view.");
+        template_function_arity_1("editor-set-mode!", "Set the editor mode.");
         template_function_arity_1(
             "editor-doc-in-view?",
-            "Check whether the current view contains a document",
+            "Check whether the current view contains a document.",
         );
         template_function_arity_1(
             "set-scratch-buffer-name!",
-            "Set the name of a scratch buffer",
+            "Set the name of a scratch buffer.",
         );
-        template_function_arity_1("editor-doc-exists?", "Check if a document exists");
-        template_function_arity_1("editor->text", "Get the document text as a rope");
-        template_function_arity_1("editor-document->path", "Get the path to a document");
-        template_function_arity_1("register->value", "Get register value as a list of strings");
-
-        template_function_arity_1("set-editor-clip-top!", "Set the editor clipping at the top");
+        template_function_arity_1("editor-doc-exists?", "Check if a document exists.");
+        template_function_arity_1("editor->text", "Get the document as a rope.");
+        template_function_arity_1("editor-document->path", "Get the path to a document.");
+        template_function_arity_1(
+            "register->value",
+            "Get register value as a list of strings.",
+        );
+        template_function_arity_1(
+            "set-editor-clip-top!",
+            "Set the editor clipping at the top.",
+        );
         template_function_arity_1(
             "set-editor-clip-right!",
-            "Set the editor clipping at the right",
+            "Set the editor clipping at the right.",
         );
         template_function_arity_1(
             "set-editor-clip-left!",
-            "Set the editor clipping at the left",
+            "Set the editor clipping at the left.",
         );
         template_function_arity_1(
             "set-editor-clip-bottom!",
-            "Set the editor clipping at the bottom",
+            "Set the editor clipping at the bottom.",
         );
 
         let mut template_function_arity_2 = |name: &str| {

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -3072,12 +3072,13 @@ fn cx_is_document_in_view(cx: &mut Context, doc_id: DocumentId) -> Option<helix_
 }
 
 fn cx_register_value(cx: &mut Context, name: char) -> Vec<String> {
-    let items = cx
-        .editor
+    cx.editor
         .registers
         .read(name, cx.editor)
-        .map_or(Vec::new(), |reg| reg.collect());
-    items.into_iter().map(|value| value.to_string()).collect()
+        .map_or(Vec::new(), |reg| reg.collect())
+        .into_iter()
+        .map(|value| value.to_string())
+        .collect()
 }
 
 fn cx_document_exists(cx: &mut Context, doc_id: DocumentId) -> bool {


### PR DESCRIPTION
#### Motivation

I wanted to explore the plugin system and create a simple plugin for searching command history, my approach was to firstly register a hook on the `'post-command` event and then get the actual command from the `:` register. However, as far as I'm aware currently there's no way to get a value from a register using steel, therefore I've prepared a simple change.

#### Summary

* Added `register->value` function, for example to display all commands executed in current session you can do: `(simple-display (register->value #\:))`  (returns a list of strings).
* Additionally, I can extend this PR to add a way to include docs for all functions with arity 1 including `register->value` as I noticed it's currently not possible to add docs for this function.