### PR TITLE
ViewID equality

### DIFF
--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -23,6 +23,7 @@ use helix_view::{
     },
     events::{DocumentDidOpen, DocumentFocusLost, DocumentSaved, SelectionDidChange},
     extension::document_id_to_usize,
+    extension::view_id_to_u64,
     graphics::CursorKind,
     input::KeyEvent,
     theme::Color,
@@ -4004,6 +4005,7 @@ fn configure_engine_impl(mut engine: Engine) -> Engine {
     });
 
     engine.register_fn("doc-id->usize", document_id_to_usize);
+    engine.register_fn("view-id->u64", view_id_to_u64);
 
     // TODO: Remove that this is now in helix/core/misc
     engine.register_fn("acquire-context-lock", acquire_context_lock);

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -3233,6 +3233,7 @@ fn configure_lsp_globals() {
             "helix-find-workspace",
             "find-workspace",
             "doc-id->usize",
+            "view-id->u64",
             "new-component!",
             "acquire-context-lock",
             "SteelDynamicComponent?",

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -3222,6 +3222,7 @@ fn configure_lsp_globals() {
     path.push("_helix-global-builtins.scm");
 
     let mut output = String::new();
+
     let names = &[
         "*helix.cx*",
         "*helix.config*",
@@ -3232,7 +3233,6 @@ fn configure_lsp_globals() {
         "helix-find-workspace",
         "find-workspace",
         "doc-id->usize",
-        "view-id->u64",
         "new-component!",
         "acquire-context-lock",
         "SteelDynamicComponent?",

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -23,7 +23,6 @@ use helix_view::{
     },
     events::{DocumentDidOpen, DocumentFocusLost, DocumentSaved, SelectionDidChange},
     extension::document_id_to_usize,
-    extension::view_id_to_u64,
     graphics::CursorKind,
     input::KeyEvent,
     theme::Color,
@@ -4018,7 +4017,6 @@ fn configure_engine_impl(mut engine: Engine) -> Engine {
     });
 
     engine.register_fn("doc-id->usize", document_id_to_usize);
-    engine.register_fn("view-id->u64", view_id_to_u64);
 
     // TODO: Remove that this is now in helix/core/misc
     engine.register_fn("acquire-context-lock", acquire_context_lock);

--- a/helix-view/src/extension.rs
+++ b/helix-view/src/extension.rs
@@ -57,7 +57,15 @@ mod steel_implementations {
     }
     impl Custom for crate::graphics::CursorKind {}
     impl Custom for DocumentId {}
-    impl Custom for ViewId {}
+    impl Custom for ViewId {
+        fn equality_hint(&self, other: &dyn steel::rvals::CustomType) -> bool {
+            if let Some(other) = as_underlying_type::<ViewId>(other) {
+                self == other
+            } else {
+                false
+            }
+        }
+    }
     impl CustomReference for Document {}
 
     impl Custom for Action {}

--- a/helix-view/src/extension.rs
+++ b/helix-view/src/extension.rs
@@ -1,11 +1,7 @@
-use crate::{DocumentId, ViewId};
+use crate::DocumentId;
 
 pub fn document_id_to_usize(doc_id: &DocumentId) -> usize {
     doc_id.0.into()
-}
-
-pub fn view_id_to_u64(view_id: &ViewId) -> u64 {
-    view_id.0.as_ffi()
 }
 
 #[cfg(feature = "steel")]

--- a/helix-view/src/extension.rs
+++ b/helix-view/src/extension.rs
@@ -1,7 +1,11 @@
-use crate::DocumentId;
+use crate::{DocumentId, ViewId};
 
 pub fn document_id_to_usize(doc_id: &DocumentId) -> usize {
     doc_id.0.into()
+}
+
+pub fn view_id_to_u64(view_id: &ViewId) -> u64 {
+    view_id.0.as_ffi()
 }
 
 #[cfg(feature = "steel")]


### PR DESCRIPTION
### Context/Use case

Wanted to check whether after a call to `jump_view_*` the current split/buffer is still the same (there are no more splits to jump to in the current direction) or has changed.

### Summary

* Enabled equality checks and identification of `ViewIds` in steel by exposing `ViewId` keys as u64 identifiers.