### PR TITLE
add some helpers to open windows and communicate with lsps

### DIFF
--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1760,7 +1760,7 @@ impl Editor {
         id
     }
 
-    fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
+    pub fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
         let id = self.new_document(doc);
         self.switch(id, action);
         id


### PR DESCRIPTION
i wanted to add a feature via the config (expanding a macro at the cursor) and i needed a few things for that to work (being able to create a `TextDocumentPositionParams` and being able to open the output in a separate view). with this pr i can just do it with this:

```scheme
(require "helix/misc.scm")
(require "helix/static.scm")
(require "helix/configuration.scm")

(define (expand-macro)
  (send-lsp-command "rust-analyzer"
                    "rust-analyzer/expandMacro"
                    (make-position-params "utf-8")
                    (λ (result) (open-view! (hash-ref result 'expansion) "rust"))))

(provide expand-macro)
```

which provides me the ability to open, here's a demo where i call `:expand-macro` for the clap `Parser` on the `Args` struct:

![image](https://github.com/user-attachments/assets/1ec10077-ce3b-44b3-aeab-6ad97f588635)

a few notes here, but i just wanted to get it out to get a little bit of feedback:

1. i was unsure of how to do functions with optional arguments, i would personally prefer the `lang` argument to be optional, but currently i have to explicitly pass in a `#f` for a `None`.
1. having to set the lsp encoding for the `make-position-encoding` is a little annoying as (i think) it currently isn't possible to get the encoding used by a specific lsp, though i think it is the more correct choice (apparently neovim had it optional and they can't change it to required now, because it would be a breaking change).
1. i have no idea what to call the `open-view!` function, but i just used `open-view!` for now, because the crate is called `helix-view`. neovim calls it `nvim_open_win` and so maybe `open-window!` might make sense too. no idea though.
1. the `open-view!` function currently always opens the window in a vertical split, it would probably be nice to be able to specify horizontal split and maybe replace as well.