### PR TITLE
Add more fns to update selection ranges

### DIFF
--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -394,6 +394,11 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
         set_selection_primary_index,
         "Set the primary index of the current selection"
     );
+    function1!(
+        "remove-current-selection-range!",
+        remove_selection_range,
+        "Remove a range from the current selection"
+    );
 
     function1!(
         "regex-selection",
@@ -4411,6 +4416,12 @@ fn set_selection_primary_index(cx: &mut Context, primary_index: usize) {
     let mut selection = doc.selection(view.id).clone();
     selection.set_primary_index(primary_index);
     doc.set_selection(view.id, selection)
+}
+
+fn remove_selection_range(cx: &mut Context, index: usize) {
+    let (view, doc) = current!(cx.editor);
+    let selection = doc.selection(view.id).clone();
+    doc.set_selection(view.id, selection.remove(index))
 }
 
 fn current_line_number(cx: &mut Context) -> usize {

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -384,6 +384,16 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
         set_selection,
         "Update the selection object to the current selection within the editor"
     );
+    function1!(
+        "push-range-to-selection!",
+        push_range_to_selection,
+        "Push a new range to a selection. The new selection will be the primary one"
+    );
+    function1!(
+        "set-current-selection-primary-index!",
+        set_selection_primary_index,
+        "Set the primary index of the current selection"
+    );
 
     function1!(
         "regex-selection",
@@ -4387,6 +4397,19 @@ fn current_selection(cx: &mut Context) -> Selection {
 
 fn set_selection(cx: &mut Context, selection: Selection) {
     let (view, doc) = current!(cx.editor);
+    doc.set_selection(view.id, selection)
+}
+
+fn push_range_to_selection(cx: &mut Context, range: Range) {
+    let (view, doc) = current!(cx.editor);
+    let selection = doc.selection(view.id).clone();
+    doc.set_selection(view.id, selection.push(range))
+}
+
+fn set_selection_primary_index(cx: &mut Context, primary_index: usize) {
+    let (view, doc) = current!(cx.editor);
+    let mut selection = doc.selection(view.id).clone();
+    selection.set_primary_index(primary_index);
     doc.set_selection(view.id, selection)
 }
 


### PR DESCRIPTION
- add more fns to update selection ranges
- mutates the active selection instead of a local selection in steel code

Some of the underlying hx impls might panic (like trying to remove the only selection range). Not sure whether the steel fn should check for that instead.

Closes (the rest of) #37 .