### PR TITLE
Add `find-split-in-direction` function

### DIFF
--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -3884,6 +3884,18 @@ last-line : int?
 "#
     );
 
+    register_2!(
+        "find-split-in-direction",
+        cx_find_split_in_direction,
+        r#"
+Find split in a direction relative to the provided view-id.
+
+```scheme
+(find-split-in-direction view-id direction) -> ViewId?
+```
+        "#
+    );
+
     if generate_sources {
         if let Some(mut target_directory) = alternative_runtime_search_path() {
             if !target_directory.exists() {
@@ -4397,6 +4409,8 @@ fn configure_engine_impl(mut engine: Engine) -> Engine {
     // Create directory since we can't do that in the current state
     engine.register_fn("hx.create-directory", create_directory);
 
+    engine.register_fn("hx.tree-direction-from-string", get_tree_direction_from_string);
+
     GLOBAL_OFFSET.set(engine.globals().len()).unwrap();
 
     engine
@@ -4621,6 +4635,24 @@ fn set_buffer_uri(cx: &mut Context, uri: SteelString) -> anyhow::Result<()> {
 
 fn cx_current_focus(cx: &mut Context) -> helix_view::ViewId {
     cx.editor.tree.focus
+}
+
+fn cx_find_split_in_direction(
+    cx: &mut Context,
+    view_id: ViewId,
+    direction: helix_view::tree::Direction,
+) -> Option<helix_view::ViewId> {
+    cx.editor.tree.find_split_in_direction(view_id, direction)
+}
+
+fn get_tree_direction_from_string(name: String) -> Option<helix_view::tree::Direction> {
+    match name.as_str() {
+        "up" => Some(helix_view::tree::Direction::Up),
+        "down" => Some(helix_view::tree::Direction::Down),
+        "left" => Some(helix_view::tree::Direction::Left),
+        "right" => Some(helix_view::tree::Direction::Right),
+        _ => None,
+    }
 }
 
 fn cx_get_document_id(cx: &mut Context, view_id: helix_view::ViewId) -> DocumentId {

--- a/helix-view/src/extension.rs
+++ b/helix-view/src/extension.rs
@@ -13,15 +13,11 @@ mod steel_implementations {
     };
 
     use crate::{
-        document::Mode,
-        editor::{
+        document::Mode, editor::{
             Action, AutoSave, BufferLine, CursorShapeConfig, FilePickerConfig, GutterConfig,
             IndentGuidesConfig, LineEndingConfig, LineNumber, LspConfig, SearchConfig,
             SmartTabConfig, StatusLineConfig, TerminalConfig, WhitespaceConfig,
-        },
-        graphics::{Color, Rect, Style, UnderlineStyle},
-        input::Event,
-        Document, DocumentId, Editor, ViewId,
+        }, graphics::{Color, Rect, Style, UnderlineStyle}, input::Event, tree::Direction, Document, DocumentId, Editor, ViewId
     };
 
     impl steel::gc::unsafe_erased_pointers::CustomReference for Editor {}
@@ -104,4 +100,5 @@ mod steel_implementations {
     impl Custom for LineEndingConfig {}
     impl Custom for SmartTabConfig {}
     impl Custom for AutoSave {}
+    impl Custom for Direction {}
 }


### PR DESCRIPTION
This PR exposes the `find_split_in_direction` method from helix' editor tree to the steel engine.

## Motivation

I have implemented some logic to share navigation keybinds between helix and tmux.

Tmux forwards the navigation key-presses if it detects that the current pane is running helix. Helix (steel) will check if a neighboring split exists in the intended direction and either jump to that split, or run a `tmux select-pane` command.

```bash
# tmux.conf

bind-key -n M-h if-shell '[ "#{pane_current_command}" = "hx" ]' \
  "send-keys M-h" \
  "select-pane -L"

bind-key -n M-j if-shell '[ "#{pane_current_command}" = "hx" ]' \
  "send-keys M-j" \
  "select-pane -D"

bind-key -n M-k if-shell '[ "#{pane_current_command}" = "hx" ]' \
  "send-keys M-k" \
  "select-pane -U"

bind-key -n M-l if-shell '[ "#{pane_current_command}" = "hx" ]' \
  "send-keys M-l" \
  "select-pane -R"
```

```scheme
;; helix.scm

(provide focus-up focus-right focus-down focus-left)

(define (focus-up)
  (if (find-split-in-direction (editor-focus) (hx.tree-direction-from-string "up"))
         (helix.static.jump_view_up)
         (helix.run-shell-command "tmux" "select-pane" "-U")))

(define (focus-right)
  (if (find-split-in-direction (editor-focus) (hx.tree-direction-from-string "right"))
         (helix.static.jump_view_right)
         (helix.run-shell-command "tmux" "select-pane" "-R")))

(define (focus-down)
  (if (find-split-in-direction (editor-focus) (hx.tree-direction-from-string "down"))
         (helix.static.jump_view_down)
         (helix.run-shell-command "tmux" "select-pane" "-D")))

(define (focus-left)
  (if (find-split-in-direction (editor-focus) (hx.tree-direction-from-string "left"))
         (helix.static.jump_view_left)
         (helix.run-shell-command "tmux" "select-pane" "-L")))
```

```scheme
;; init.scm

(keymap (global)
        (normal (A-h ":focus-left")
                (A-j ":focus-down")
                (A-k ":focus-up")
                (A-l ":focus-right")))
```