### PR TITLE
added a selected-register! function for the plugin system

### DIFF
--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -1709,6 +1709,11 @@ Get the `Rect` associated with the currently focused buffer.
 ```
         "#
     );
+    register_0!(
+        "selected-register!",
+        |cx: &mut Context| cx.editor.selected_register.unwrap_or(cx.editor.config().default_yank_register),
+        r#"Get currently selected register"#
+    );
 
     // Arity 1
     module.register_fn("editor->doc-id", cx_get_document_id);


### PR DESCRIPTION
I find it difficult to use set-register-value from https://github.com/mattwparas/helix/pull/26 or register->value without knowing the selected register and couldn't find an existing function to do this.

I wanted to have an alternative to replace-with-yanked that worked like vim (yank the replaced text), so now this works:

```scheme
(provide yank-and-replace-with-prev-yanked)
(define (yank-and-replace-with-prev-yanked)
  (define cur-reg (helix.editor.selected-register!))
  (define old-yank (car (helix.editor.register->value cur-reg)))
  (helix.static.yank)
  (helix.static.replace-selection-with old-yank))

```