### PR TITLE
Add integration for handling LSP method calls

### DIFF
--- a/helix-core/src/test.rs
+++ b/helix-core/src/test.rs
@@ -286,10 +286,7 @@ mod test {
     #[test]
     fn print_multi_code_point_grapheme() {
         assert_eq!(
-            (
-                String::from("hello 👨‍👩‍👧‍👦 goodbye"),
-                Selection::single(13, 6)
-            ),
+            (String::from("hello 👨‍👩‍👧‍👦 goodbye"), Selection::single(13, 6)),
             print("hello #[|👨‍👩‍👧‍👦]# goodbye")
         );
     }

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -463,6 +463,8 @@ pub enum MethodCall {
     RegisterCapability(lsp::RegistrationParams),
     UnregisterCapability(lsp::UnregistrationParams),
     ShowDocument(lsp::ShowDocumentParams),
+    // Other kind specifically for extensions
+    Other(String, jsonrpc::Params),
 }
 
 impl MethodCall {
@@ -494,9 +496,7 @@ impl MethodCall {
                 let params: lsp::ShowDocumentParams = params.parse()?;
                 Self::ShowDocument(params)
             }
-            _ => {
-                return Err(Error::Unhandled);
-            }
+            _ => Self::Other(method.to_owned(), params)
         };
         Ok(request)
     }

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -496,7 +496,7 @@ impl MethodCall {
                 let params: lsp::ShowDocumentParams = params.parse()?;
                 Self::ShowDocument(params)
             }
-            _ => Self::Other(method.to_owned(), params)
+            _ => Self::Other(method.to_owned(), params),
         };
         Ok(request)
     }

--- a/helix-term/src/commands/engine.rs
+++ b/helix-term/src/commands/engine.rs
@@ -1,3 +1,4 @@
+use ::steel::SteelVal;
 use arc_swap::{ArcSwap, ArcSwapAny};
 use helix_core::syntax;
 use helix_lsp::{jsonrpc, LanguageServerId};
@@ -141,21 +142,29 @@ impl ScriptingEngine {
             .collect()
     }
 
-    pub fn handle_lsp_notification(
+    pub fn handle_lsp_call(
         cx: &mut compositor::Context,
         server_id: LanguageServerId,
         event_name: String,
+        call_id: jsonrpc::Id,
         params: jsonrpc::Params,
-    ) {
+    ) -> Option<SteelVal> {
         for kind in PLUGIN_PRECEDENCE {
-            if manual_dispatch!(
+            if let Some(value) = manual_dispatch!(
                 kind,
                 // TODO: Get rid of these clones!
-                handle_lsp_notification(cx, server_id, event_name.clone(), params.clone())
+                handle_lsp_call(
+                    cx,
+                    server_id,
+                    event_name.clone(),
+                    call_id.clone(),
+                    params.clone()
+                )
             ) {
-                return;
+                return Some(value);
             }
         }
+        return None;
     }
 
     pub fn generate_sources() {
@@ -229,14 +238,15 @@ pub trait PluginSystem {
     /// Call into the scripting engine to handle an unhandled LSP notification, sent from the server
     /// to the client.
     #[inline(always)]
-    fn handle_lsp_notification(
+    fn handle_lsp_call(
         &self,
         _cx: &mut compositor::Context,
         _server_id: LanguageServerId,
         _event_name: String,
+        _call_id: jsonrpc::Id,
         _params: jsonrpc::Params,
-    ) -> bool {
-        false
+    ) -> Option<SteelVal> {
+        None
     }
 
     /// Given an identifier, extract the documentation from the engine.

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -16,6 +16,7 @@ use helix_core::{
     Range, Selection, Tendril, Transaction,
 };
 use helix_event::register_hook;
+use helix_lsp::jsonrpc;
 use helix_view::{
     annotations::diagnostics::DiagnosticFilter,
     document::{DocumentInlayHints, DocumentInlayHintsId, Mode},
@@ -198,13 +199,22 @@ static BUFFER_EXTENSION_KEYMAP: Lazy<RwLock<BufferExtensionKeyMap>> = Lazy::new(
     })
 });
 
-pub static LSP_NOTIFICATION_REGISTRY: Lazy<RwLock<HashMap<(String, String), RootedSteelVal>>> =
+pub static LSP_CALL_REGISTRY: Lazy<RwLock<HashMap<(String, String), RootedSteelVal>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
+
+fn register_lsp_call_callback(lsp: String, kind: String, function: SteelVal) {
+    let rooted = function.as_rooted();
+
+    LSP_CALL_REGISTRY
+        .write()
+        .unwrap()
+        .insert((lsp, kind), rooted);
+}
 
 fn register_lsp_notification_callback(lsp: String, kind: String, function: SteelVal) {
     let rooted = function.as_rooted();
 
-    LSP_NOTIFICATION_REGISTRY
+    LSP_CALL_REGISTRY
         .write()
         .unwrap()
         .insert((lsp, kind), rooted);
@@ -776,6 +786,8 @@ fn load_configuration_api(engine: &mut Engine, generate_sources: bool) {
         register_lsp_notification_callback,
     );
 
+    module.register_fn("register-lsp-call-handler", register_lsp_call_callback);
+
     module.register_fn("update-configuration!", |ctx: &mut Context| {
         ctx.editor
             .config_events
@@ -970,9 +982,31 @@ fn load_configuration_api(engine: &mut Engine, generate_sources: bool) {
 ;; ```
 ;; (register-lsp-notification-handler "dart"
 ;;                                    "dart/textDocument/publishClosingLabels"
-;;                                    (lambda (args) (displayln args)))
+;;                                    (lambda (call-id args) (displayln args)))
 ;; ```
 (define register-lsp-notification-handler helix.register-lsp-notification-handler)
+
+(provide register-lsp-call-handler)
+
+;;@doc
+;; Register a callback to be called on LSP calls sent from the server -> client
+;; that aren't currently handled by Helix as a built in.
+;;
+;; ```scheme
+;; (register-lsp-call-handler lsp-name event-name handler)
+;; ```
+;;
+;; * lsp-name : string?
+;; * event-name : string?
+;; * function : (-> hash? any?) ;; Function where the first argument is the parameters
+;;
+;; # Examples
+;; ```
+;; (register-lsp-call-handler "dart"
+;;                                    "dart/textDocument/publishClosingLabels"
+;;                                    (lambda (call-id args) (displayln args)))
+;; ```
+(define register-lsp-call-handler helix.register-lsp-call-handler)
 
 (provide set-option!)
 (define (set-option! key value)
@@ -2138,14 +2172,15 @@ impl super::PluginSystem for SteelScriptingEngine {
 
     // TODO: Should this just be a hook / event instead of a function like this?
     // Handle an LSP notification, assuming its been sent through
-    fn handle_lsp_notification(
+    fn handle_lsp_call(
         &self,
         cx: &mut compositor::Context,
         server_id: helix_lsp::LanguageServerId,
         event_name: String,
+        call_id: jsonrpc::Id,
         params: helix_lsp::jsonrpc::Params,
-    ) -> bool {
-        if let Err(e) = enter_engine(|guard| {
+    ) -> Option<SteelVal> {
+        let result = enter_engine(|guard| {
             {
                 let mut ctx = Context {
                     register: None,
@@ -2168,7 +2203,7 @@ impl super::PluginSystem for SteelScriptingEngine {
 
                 let language_server_name = language_server_name.unwrap();
 
-                let function = LSP_NOTIFICATION_REGISTRY
+                let function = LSP_CALL_REGISTRY
                     .read()
                     .unwrap()
                     .get(&(language_server_name, event_name))
@@ -2189,7 +2224,11 @@ impl super::PluginSystem for SteelScriptingEngine {
                                     .map_err(|e| SteelErr::new(ErrorKind::Generic, e.to_string()))
                                     .and_then(|x| x.into_steelval())?;
 
-                                let args = vec![params];
+                                let call_id = serde_json::to_value(&call_id)
+                                    .map_err(|e| SteelErr::new(ErrorKind::Generic, e.to_string()))
+                                    .and_then(|x| x.into_steelval())?;
+
+                                let args = vec![call_id, params];
 
                                 engine.call_function_with_args(function.clone(), args)
                             })
@@ -2198,10 +2237,15 @@ impl super::PluginSystem for SteelScriptingEngine {
                     Ok(SteelVal::Void)
                 }
             }
-        }) {
-            cx.editor.set_error(format!("{}", e));
+        });
+
+        match result {
+            Err(e) => {
+                cx.editor.set_error(format!("{}", e));
+                Some(SteelVal::Void)
+            }
+            Ok(value) => Some(value),
         }
-        true
     }
 }
 
@@ -3750,6 +3794,33 @@ callback : (-> any?)
         );
     }
 
+    module.register_fn("lsp-reply-ok", lsp_reply_ok);
+    if generate_sources {
+        builtin_misc_module.push_str(
+            r#"
+    (provide lsp-reply-ok)
+    ;;@doc
+    ;; Send a successful reply to an LSP request with the given result.
+    ;;
+    ;; ```scheme
+    ;; (lsp-reply-ok lsp-name request-id result)
+    ;; ```
+    ;; 
+    ;; * lsp-name : string? - Name of the language server
+    ;; * request-id : string? - ID of the request to respond to  
+    ;; * result : any? - The result value to send back
+    ;;
+    ;; # Examples
+    ;; ```scheme
+    ;; ;; Reply to a request with id "123" from rust-analyzer
+    ;; (lsp-reply-ok "rust-analyzer" "123" (hash "result" "value"))
+    ;; ```
+    (define (lsp-reply-ok lsp-name request-id result)
+        (helix.lsp-reply-ok *helix.cx* lsp-name request-id result))    
+            "#,
+        );
+    }
+
     macro_rules! register_2_no_context {
         ($name:expr, $func:expr, $doc:expr) => {{
             module.register_fn($name, $func);
@@ -5142,6 +5213,39 @@ fn send_arbitrary_lsp_command(
     create_callback(cx, future, rooted)?;
 
     Ok(())
+}
+
+fn lsp_reply_ok(
+    cx: &mut Context,
+    name: SteelString,
+    id: SteelString,
+    result: SteelVal,
+) -> anyhow::Result<()> {
+    let serde_value: Result<serde_json::Value, steel::SteelErr> = result.try_into();
+    let value = match serde_value {
+        Ok(serialized_value) => serialized_value,
+        Err(error) => {
+            log::warn!("Failed to serialize a SteelVal: {}", error);
+            serde_json::Value::Null
+        }
+    };
+
+    let (_view, doc) = current!(cx.editor);
+
+    let language_server_id = anyhow::Context::context(
+        doc.language_servers().find(|x| x.name() == name.as_str()),
+        "Unable to find the language server specified!",
+    )?
+    .id();
+
+    cx.editor
+        .language_server_by_id(language_server_id)
+        .ok_or(anyhow::anyhow!("Failed to find a language server by id"))
+        .and_then(|language_server| {
+            language_server
+                .reply(jsonrpc::Id::Str(id.to_string()), Ok(value))
+                .map_err(Into::into)
+        })
 }
 
 fn create_callback<T: TryInto<SteelVal, Error = SteelErr> + 'static>(

--- a/helix-term/src/events.rs
+++ b/helix-term/src/events.rs
@@ -1,8 +1,9 @@
 use helix_event::{events, register_event};
 use helix_view::document::Mode;
 use helix_view::events::{
-    ConfigDidChange, DocumentSaved, DiagnosticsDidChange, DocumentDidChange, DocumentDidClose, DocumentDidOpen,
-    DocumentFocusLost, LanguageServerExited, LanguageServerInitialized, SelectionDidChange,
+    ConfigDidChange, DiagnosticsDidChange, DocumentDidChange, DocumentDidClose, DocumentDidOpen,
+    DocumentFocusLost, DocumentSaved, LanguageServerExited, LanguageServerInitialized,
+    SelectionDidChange,
 };
 
 use crate::commands;


### PR DESCRIPTION
This PR adds a way to handle unprocessed LSP calls of type `Call::MethodCall` the same way it was [recently implemented](https://github.com/mattwparas/helix/commit/2fe135cf7db32def1efb1c7b44ea5429979060a0) for `Call::Notification`. These two cases are extremely similar and the only difference is that language server might expect a reply to a method call. This makes it possible to use the same API for both with the only difference that notifications ignore the return value.

I introduced a new function `register-lsp-call-handler` - it does the same thing that the `register-lsp-notification-handler` did but has a more generic name. I decided to keep the  `register-lsp-notification-handler` for now to avoid breaking the existing plugins