### PR TITLE
add function to get language for document

### DIFF
--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -1752,6 +1752,8 @@ Get the `Rect` associated with the currently focused buffer.
         },
     );
 
+    module.register_fn("editor-document->language", cx_get_document_language);
+
     module.register_fn(
         "editor-document-dirty?",
         |cx: &mut Context, doc: DocumentId| -> Option<bool> {
@@ -1843,6 +1845,11 @@ Get the `Rect` associated with the currently focused buffer.
         template_function_arity_1(
             "editor-document-last-saved",
             "Check when a document was last saved (returns a `SystemTime`)",
+        );
+
+        template_function_arity_1(
+            "editor-document->language",
+            "Get the language for the document",
         );
 
         template_function_arity_1(
@@ -4719,6 +4726,13 @@ fn document_path(cx: &mut Context, doc_id: DocumentId) -> Option<String> {
 
 fn cx_editor_all_documents(cx: &mut Context) -> Vec<DocumentId> {
     cx.editor.documents.keys().copied().collect()
+}
+
+fn cx_get_document_language(cx: &mut Context, doc_id: DocumentId) -> Option<String> {
+    cx.editor
+        .documents
+        .get(&doc_id)
+        .and_then(|d| Some(d.language_name()?.to_string()))
 }
 
 fn cx_switch(cx: &mut Context, doc_id: DocumentId) {

--- a/steel-docs.md
+++ b/steel-docs.md
@@ -712,6 +712,8 @@ Set the URI of the buffer
 Check if a document exists.
 ### **editor-document-last-saved**
 Check when a document was last saved (returns a `SystemTime`)
+### **editor-document->language**
+Get the language for the document
 ### **editor-document-dirty?**
 Check if a document has unsaved changes
 ### **editor->text**


### PR DESCRIPTION
Hey, 

in [csharp-hx](https://github.com/jdrst/csharp-hx) i'm sending out-of-spec lsp-commands. 
To do that, a way to check if a buffer/document makes use of the respective language-server, would be great. 
Hence this PR.

