### PR TITLE
Add send-lsp-notification Steel binding

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -516,25 +516,6 @@ impl Client {
         }
     }
 
-    /// Send a custom RPC notification with arbitrary method and params to the language server.
-    pub fn send_custom_notification(&self, method: String, params: Option<Value>) -> Result<()> {
-        let server_tx = self.server_tx.clone();
-
-        let params = params.unwrap_or(Value::Null);
-
-        let notification = jsonrpc::Notification {
-            jsonrpc: Some(jsonrpc::Version::V2),
-            method,
-            params: Self::value_into_params(params),
-        };
-
-        server_tx
-            .send(Payload::Notification(notification))
-            .map_err(|e| Error::Other(e.into()))?;
-
-        Ok(())
-    }
-
     /// Reply to a language server RPC call.
     pub fn reply(
         &self,
@@ -1626,6 +1607,25 @@ impl Client {
                 .map_err(|_| Error::Timeout(id))? // return Timeout
                 .ok_or(Error::StreamClosed)?
         }
+    }
+
+    /// Send a custom RPC notification with arbitrary method and params to the language server.
+    pub fn send_custom_notification(&self, method: String, params: Option<Value>) -> Result<()> {
+        let server_tx = self.server_tx.clone();
+
+        let params = params.unwrap_or(Value::Null);
+
+        let notification = jsonrpc::Notification {
+            jsonrpc: Some(jsonrpc::Version::V2),
+            method,
+            params: Self::value_into_params(params),
+        };
+
+        server_tx
+            .send(Payload::Notification(notification))
+            .map_err(|e| Error::Other(e.into()))?;
+
+        Ok(())
     }
 }
 

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -516,6 +516,25 @@ impl Client {
         }
     }
 
+    /// Send a custom RPC notification with arbitrary method and params to the language server.
+    pub fn send_custom_notification(&self, method: String, params: Option<Value>) -> Result<()> {
+        let server_tx = self.server_tx.clone();
+
+        let params = params.unwrap_or(Value::Null);
+
+        let notification = jsonrpc::Notification {
+            jsonrpc: Some(jsonrpc::Version::V2),
+            method,
+            params: Self::value_into_params(params),
+        };
+
+        server_tx
+            .send(Payload::Notification(notification))
+            .map_err(|e| Error::Other(e.into()))?;
+
+        Ok(())
+    }
+
     /// Reply to a language server RPC call.
     pub fn reply(
         &self,

--- a/helix-term/src/commands/engine/steel.rs
+++ b/helix-term/src/commands/engine/steel.rs
@@ -3836,6 +3836,7 @@ callback : (-> any?)
     );
 
     module.register_fn("send-lsp-command", send_arbitrary_lsp_command);
+    module.register_fn("send-lsp-notification", send_arbitrary_lsp_notification);
     if generate_sources {
         builtin_misc_module.push_str(
             r#"
@@ -3858,6 +3859,33 @@ callback : (-> any?)
     ;; ```
     (define (send-lsp-command lsp-name method-name params callback)
         (helix.send-lsp-command *helix.cx* lsp-name method-name params callback))
+            "#,
+        );
+    }
+
+    if generate_sources {
+        builtin_misc_module.push_str(
+            r#"
+    (provide send-lsp-notification)
+    ;;@doc
+    ;; Send an LSP notification. The `lsp-name` must correspond to an active LSP.
+    ;; The method name corresponds to the method name that you'd expect to see
+    ;; with the LSP, and the params can be passed as a hash table. Unlike
+    ;; `send-lsp-command`, this does not expect a response and is used for
+    ;; fire-and-forget notifications.
+    ;; 
+    ;; # Example
+    ;; ```scheme
+    ;; (define (send-completion-notification)
+    ;;   (send-lsp-notification "copilot-ls"
+    ;;                         "textDocument/didShowCompletion"
+    ;;                         (hash "item" 
+    ;;                               (hash "insertText" "a helpful suggestion"
+    ;;                                     "range" (hash "start" (hash "line" 1 "character" 0)
+    ;;                                                   "end" (hash "line" 1 "character" 2))))))
+    ;; ```
+    (define (send-lsp-notification lsp-name method-name params)
+        (helix.send-lsp-notification *helix.cx* lsp-name method-name params))
             "#,
         );
     }
@@ -5332,6 +5360,33 @@ fn lsp_reply_ok(
                 .reply(jsonrpc::Id::Str(id.to_string()), Ok(value))
                 .map_err(Into::into)
         })
+}
+
+fn send_arbitrary_lsp_notification(
+    cx: &mut Context,
+    name: SteelString,
+    method: SteelString,
+    params: Option<SteelVal>,
+) -> anyhow::Result<()> {
+    let argument = params.map(|x| serde_json::Value::try_from(x).unwrap());
+
+    let (_view, doc) = current!(cx.editor);
+
+    let language_server_id = anyhow::Context::context(
+        doc.language_servers().find(|x| x.name() == name.as_str()),
+        "Unable to find the language server specified!",
+    )?
+    .id();
+
+    let language_server = cx
+        .editor
+        .language_server_by_id(language_server_id)
+        .ok_or(anyhow::anyhow!("Failed to find a language server by id"))?;
+
+    // Send the notification using the custom method and arguments
+    language_server.send_custom_notification(method.to_string(), argument)?;
+
+    Ok(())
 }
 
 fn create_callback<T: TryInto<SteelVal, Error = SteelErr> + 'static>(


### PR DESCRIPTION
- Add send_custom_notification method to LSP Client for arbitrary notifications
- Implement send_arbitrary_lsp_notification Steel function following existing patterns
- Register Steel binding with comprehensive documentation and examples
- Enable fire-and-forget LSP notifications from Steel scripts
- Supports arbitrary method names and parameters like textDocument/didShowCompletion
- Follows same error handling and language server discovery as send-lsp-command

Enables usage like
```scheme
(send-lsp-notification "copilot-ls" "textDocument/didShowCompletion"
                      (hash "item" (hash "insertText" "suggestion")))
```