### PR TITLE
create new `(get-current-line-character)` to give columns with encoding

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -543,6 +543,12 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
         after the existing function context has exited."
     );
 
+    function1!(
+        "get-current-line-character",
+        current_line_character,
+        "Returns the current column number with the given position encoding"
+    );
+
     let mut template_function_arity_0 = |name: &str, doc: &str| {
         if generate_sources {
             let docstring = format_docstring(doc);
@@ -597,7 +603,7 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
     function0!(
         "get-current-column-number",
         current_column_number,
-        "Returns the current column number"
+        "Returns the visual current column number of unicode graphemes"
     );
     function0!(
         "current-selection-object",
@@ -4769,13 +4775,11 @@ fn remove_selection_range(cx: &mut Context, index: usize) {
 
 fn current_line_number(cx: &mut Context) -> usize {
     let (view, doc) = current_ref!(cx.editor);
-    helix_core::coords_at_pos(
-        doc.text().slice(..),
+    doc.text().char_to_line(
         doc.selection(view.id)
             .primary()
             .cursor(doc.text().slice(..)),
     )
-    .row
 }
 
 fn current_column_number(cx: &mut Context) -> usize {
@@ -4787,6 +4791,19 @@ fn current_column_number(cx: &mut Context) -> usize {
             .cursor(doc.text().slice(..)),
     )
     .col
+}
+
+fn current_line_character(cx: &mut Context, encoding: SteelString) -> anyhow::Result<usize> {
+    let (view, doc) = current_ref!(cx.editor);
+
+    let encoding = match &***encoding {
+        "utf-8" => helix_lsp::OffsetEncoding::Utf8,
+        "utf-16" => helix_lsp::OffsetEncoding::Utf16,
+        "utf-32" => helix_lsp::OffsetEncoding::Utf32,
+        _ => anyhow::bail!("invalid encoding {encoding:?}"),
+    };
+
+    Ok(doc.position(view.id, encoding).character as usize)
 }
 
 fn get_selection(cx: &mut Context) -> String {


### PR DESCRIPTION
`helix_core::coords_at_pos` returns the column in graphemes (see [helix-core/src/position.rs#L101](https://github.com/helix-editor/helix/blob/00dbca93c4ce25a9be79cdb3e80fc51004127594/helix-core/src/position.rs#L101)), which is pretty much always incorrect.

if you want to communicate with lsps, which i think is the intendend use case for this fn, you have to give them the position in the encoding it expects, which you can find out by querying for the offset_encoding of the relevant client (which i am not quite sure how to get, but it should at least be possible). if this function was intended for something else, this should be made extremely clear and there should be a second function for communicating with lsps. 

i could (maybe, not sure how) make the `encoding` parameter optional, but i think having to supply it is the more correct option. the neovim equivalent, `vim.lsp.util.make_position_params()`, for example has to give a warning if it is called without an explicit encoding, as it making the parameter non-optional would be a breaking change.

i am not sure how, but it might make sense to make the encoding be a symbol instead of a string, so you would pass `'utf-8` instead of `"utf-8"`. let me know what you think.

as a drive-by-improvement make the `get-current-line` function a little simpler and better by simply calling `char_to_line` instead of going through the `helix_cure::coords_at_pos` fn.

cc @quantonganh because you implemented the function and might be surprised if updating changes it