### PR TITLE
add some functions to get lsp clients and info from them

### DIFF
--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -100,3 +100,6 @@ impl Diagnostic {
         self.severity.unwrap_or(Severity::Warning)
     }
 }
+
+#[cfg(feature = "steel")]
+impl steel::rvals::Custom for LanguageServerId {}

--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -100,6 +100,3 @@ impl Diagnostic {
         self.severity.unwrap_or(Severity::Warning)
     }
 }
-
-#[cfg(feature = "steel")]
-impl steel::rvals::Custom for LanguageServerId {}

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -18,7 +18,7 @@ use helix_core::{
     Range, Selection, Tendril, Transaction,
 };
 use helix_event::register_hook;
-use helix_lsp::{jsonrpc, LanguageServerId};
+use helix_lsp::jsonrpc;
 use helix_view::{
     annotations::diagnostics::DiagnosticFilter,
     document::{DocumentInlayHints, DocumentInlayHintsId, Mode},
@@ -4126,6 +4126,14 @@ fn load_misc_api(engine: &mut Engine, generate_sources: bool) {
         "Return the new mode from the event payload",
     );
 
+    module.register_fn("lsp-client-name", lsp_client_name);
+    template_function_no_context("lsp-client-name", "Get the name of the lsp client");
+    module.register_fn("lsp-client-offset-encoding", lsp_client_offset_encoding);
+    template_function_no_context(
+        "lsp-client-offset-encoding",
+        "Get the offset encoding of the lsp client",
+    );
+
     let mut template_function_arity_1 = |name: &str, doc: &str| {
         let doc = format_docstring(doc);
         if generate_sources {
@@ -4241,17 +4249,6 @@ callback : (-> any?)
         "set-error!",
         set_error,
         "Sets the content of the status line, with the error severity"
-    );
-
-    register_1!(
-        "lsp-client-name",
-        lsp_client_name,
-        "Get the name of the lsp client"
-    );
-    register_1!(
-        "lsp-client-offset-encoding",
-        lsp_client_offset_encoding,
-        "Get the offset encoding of the lsp client"
     );
 
     module.register_fn("send-lsp-command", send_arbitrary_lsp_command);
@@ -5706,27 +5703,42 @@ fn move_window_to_the_right(cx: &mut Context) {
     {}
 }
 
+#[derive(Debug, Clone)]
+struct LspClient {
+    name: String,
+    offset_encoding: helix_lsp::OffsetEncoding,
+}
+
+impl LspClient {
+    fn new(client: &helix_lsp::Client) -> Self {
+        LspClient {
+            name: client.name().to_owned(),
+            offset_encoding: client.offset_encoding(),
+        }
+    }
+}
+
+impl Custom for LspClient {}
+
 fn get_active_lsp_clients(cx: &mut Context) -> SteelVal {
     let (_, doc) = current!(cx.editor);
     SteelVal::ListV(
         doc.language_servers()
-            .map(|client| client.id().into_steelval().unwrap())
+            .map(|client| LspClient::new(client).into_steelval().unwrap())
             .collect(),
     )
 }
 
-fn lsp_client_name(cx: &mut Context, client: LanguageServerId) -> Option<String> {
-    let client = cx.editor.language_servers.get_by_id(client);
-    client.map(|client| client.name().to_owned())
+fn lsp_client_name(client: LspClient) -> String {
+    client.name.clone()
 }
 
-fn lsp_client_offset_encoding(cx: &mut Context, client: LanguageServerId) -> Option<&'static str> {
-    let client = cx.editor.language_servers.get_by_id(client);
-    client.map(|client| match client.offset_encoding() {
+fn lsp_client_offset_encoding(client: LspClient) -> &'static str {
+    match client.offset_encoding {
         helix_lsp::OffsetEncoding::Utf8 => "utf-8",
         helix_lsp::OffsetEncoding::Utf16 => "utf-16",
         helix_lsp::OffsetEncoding::Utf32 => "utf-32",
-    })
+    }
 }
 
 fn send_arbitrary_lsp_command(

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1831,6 +1831,7 @@ impl Document {
             .unwrap_or_else(|| self.config.load().path_completion)
     }
 
+    #[cfg(feature = "steel")]
     pub fn arc_language_servers(&self) -> impl Iterator<Item = Arc<helix_lsp::Client>> + use<'_> {
         self.language_config().into_iter().flat_map(move |config| {
             config.language_servers.iter().filter_map(move |features| {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1831,6 +1831,19 @@ impl Document {
             .unwrap_or_else(|| self.config.load().path_completion)
     }
 
+    pub fn arc_language_servers(&self) -> impl Iterator<Item = Arc<helix_lsp::Client>> + use<'_> {
+        self.language_config().into_iter().flat_map(move |config| {
+            config.language_servers.iter().filter_map(move |features| {
+                let ls = self.language_servers.get(&features.name)?.clone();
+                if ls.is_initialized() {
+                    Some(ls)
+                } else {
+                    None
+                }
+            })
+        })
+    }
+
     /// maintains the order as configured in the language_servers TOML array
     pub fn language_servers(&self) -> impl Iterator<Item = &helix_lsp::Client> {
         self.language_config().into_iter().flat_map(move |config| {


### PR DESCRIPTION
when i added a function to expand the current macro in rust i had to assume the offset encoding for rust analyzer to be utf-8, because there was no way to check for it.

so this pr adds three new functions: `(get-active-lsp-clients)` to get all lsp clients attached to the current buffer and the functions `(lsp-client-name)` and `(lsp-client-offset-encoding)` to get info about the name and the offset encoding from the client.

as the `helix_lsp::Client` struct is not `Clone` and i am not able to `impl Custom for Arc<helix_lsp::Client>` due to orphan rules, i cannot pass it directly to the steel plugins. since that would have been the most straight forward option, i wasn't sure what the best way to still implement those functions, but here are the two options i came up with:

1. pass over the `LanguageServerId` to the steel side, and then always just query back from the global map of lsps, and then get the info then. this would save a bunch of clones, but i don't know if the `LanguageServerId` is guaranteed to never be reused, and it feels a little clunky to always have to index back into the global map of lsps, meaning that both functions also require the `Context`.

2. eagerly clone all the values out of the `helix_lsp::Client` struct into a separate struct. this would probably be the more robust version, and, as far as i can tell, once the lsp is attached, the `helix_lsp::Client` is immutable, so i don't think you would have to worry about the information de-syncing.

in the second version (in contrast to the first), you can actually query for lsp info, even if the lsp has already been detached. i am not sure if that is actually the more desirable behaviour, though.

i implemented both options in here and just implemented the second on top of the first in a separate commit, so you can choose the approach you prefer (or if you prefer a completely different approach, i can implement that too).

there is probably quite a bit more information, that i could query from the lsp, but i think those two are at least a start and i didn't want to go overboard in this initial pr.

with this patch i can do this in my helix config, and always use the correct offset encoding, even if rust-analyzer would change it:

```scheme
(define (find-lsp-client-by-name clients name)
  (cond
    [(empty? clients) #f]
    [(equal? (lsp-client-name (car clients)) name) (car clients)]
    [else (find-lsp-client-by-name (cdr clients) name)]))

(define (expand-macro)
  ; find the lsp with the name "rust-analyzer" ...
  (define rust-analyzer (find-lsp-client-by-name (get-active-lsp-clients) "rust-analyzer"))
  (when rust-analyzer
    (send-lsp-command
     "rust-analyzer"
     "rust-analyzer/expandMacro"
     (hash "textDocument"
           (hash "uri" (string-append "file://" (cx->current-file)))
           "position"
           (hash "line"
                 (get-current-line-number)
                 "character"
                 ; ... and give the textDocument position with the correct encoding
                 (get-current-line-character (lsp-client-offset-encoding rust-analyzer))))
     (λ (result)
       (if (not (void? result))
           (open-expansion result)
           (set-status! "no macro at current position"))))))
```