### PR TITLE
don't unwrap language_server_name when it is None

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -2594,11 +2594,10 @@ impl super::PluginSystem for SteelScriptingEngine {
             .get_by_id(server_id)
             .map(|x| x.name().to_owned());
 
-        if language_server_name.is_none() {
+        let Some(language_server_name) = language_server_name else {
             ctx.editor.set_error("Unable to find language server");
-        }
-
-        let language_server_name = language_server_name.unwrap();
+            return None;
+        };
 
         let mut pass_call_id = false;
 


### PR DESCRIPTION
previously it would check if `language_server_name.is_none()`, set the status ... and then unwrap the option like two lines later anyway lol, causing helix to crash:

<img width="1060" height="206" alt="image" src="https://github.com/user-attachments/assets/f7478c5e-4ced-44f8-8921-1e0afb307d97" />

so refactor to use a let ... else and diverge there. i wasn't sure what to return exactly, so i just return `None` for now, but lmk if i should return something different.