### PR TITLE
make msrv 1.82 again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "imbl"
-version = "6.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fade8ae6828627ad1fa094a891eccfb25150b383047190a3648d66d06186501"
+checksum = "33afdc5d333c1a43f1f640bfc6ad3788729e5b2f18472e5d33a9187315257f8e"
 dependencies = [
  "archery",
  "bitmaps 3.2.1",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.84.0"
 components = ["rustfmt", "rust-src", "clippy"]


### PR DESCRIPTION
this locks imbl to version 6.0.0 in the lock file, as version 6.1.0 raised the msrv to 1.85 (in https://github.com/jneem/imbl/pull/134).

i changed the `rust-toolchain.toml` back to 1.84 (so before the last merge from master). i could theoretically change it back to 1.82 (as it should compile on version 1.82), but you explicitly bumped it in 7e800e3d40d17dfd21377d998019ae513c812a24 due to "windows c abi incompatibility". i compiled it on a windows machine with rust 1.82 and i didn't get any warnings or errors, but i wasn't sure exactly what that meant so i just left it at 1.84.

this should maybe fix #72? but i think that is mostly an accidental byproduct.