### PR TITLE
fix clippy warnings again

### DIFF
--- a/helix-core/src/extensions.rs
+++ b/helix-core/src/extensions.rs
@@ -100,9 +100,9 @@ pub mod steel_implementations {
             };
             // arity *must* be one
             if func.get_arity().unwrap_or(1) == 1 {
-                return Ok(TreeSitterQueryLoader { fun });
+                Ok(TreeSitterQueryLoader { fun })
             } else {
-                return Err(format!("Bad Arity: {}", func.arity.unwrap()));
+                Err(format!("Bad Arity: {}", func.arity.unwrap()))
             }
         }
 
@@ -128,7 +128,7 @@ pub mod steel_implementations {
                 steel::rvals::as_underlying_type::<TreeSitterQuery>(custom.write().as_ref())
                     .map(|t| t.clone());
 
-            return Ok(tsquery);
+            Ok(tsquery)
         }
     }
 
@@ -209,9 +209,7 @@ pub mod steel_implementations {
             }
             let mut captures: BTreeMap<String, Vec<TreeSitterNode>> = BTreeMap::new();
             let mut layers: Vec<(Layer, TreeSitterTree)> = vec![];
-            let load = |lang| {
-                return query_map.get(&lang).map(|q| q.get_inner().as_ref());
-            };
+            let load = |lang| query_map.get(&lang).map(|q| q.get_inner().as_ref());
 
             for event in syn.query_iter::<_, (), _>(source, load, lower..upper) {
                 let QueryIterEvent::Match(m) = event else {
@@ -329,7 +327,7 @@ pub mod steel_implementations {
         pub fn print_tree(&self) -> String {
             let mut output = String::new();
             let _ = pretty_print_tree(&mut output, self.inner.clone());
-            return output;
+            output
         }
         pub fn new(node: Node<'_>, t: &TreeSitterTree) -> TreeSitterNode {
             // rely on the fact that when copying the treesitter tree, there is refcounting (we keep it alive :D): https://github.com/tree-sitter/tree-sitter/blob/630fa52717f2c575a53e21b1d324ade8e528b0bd/lib/src/tree.c#L24
@@ -348,11 +346,11 @@ pub mod steel_implementations {
                 r.tree = root.tree;
                 std::mem::transmute(r)
             };
-            return TreeSitterNode {
+            TreeSitterNode {
                 inner: extended,
                 _tree: Arc::clone(t.get_inner()),
                 _lang: t.get_language(),
-            };
+            }
         }
 
         fn new_internal(&self, node: Node<'static>) -> TreeSitterNode {

--- a/helix-core/src/extensions.rs
+++ b/helix-core/src/extensions.rs
@@ -115,7 +115,7 @@ pub mod steel_implementations {
                 ));
             };
 
-            let val = (func.function)(&vec![lang.clone()])?;
+            let val = (func.function)(&[lang.clone()])?;
 
             let SteelVal::Custom(custom) = val else {
                 return Ok(None);
@@ -123,7 +123,7 @@ pub mod steel_implementations {
 
             let tsquery =
                 steel::rvals::as_underlying_type::<TreeSitterQuery>(custom.write().as_ref())
-                    .map(|t| t.clone());
+                    .cloned();
 
             Ok(tsquery)
         }
@@ -266,7 +266,7 @@ pub mod steel_implementations {
         }
         pub fn get_root(&self) -> TreeSitterNode {
             let node = self.inner.root_node();
-            let extended = unsafe { std::mem::transmute::<_, Node<'static>>(node) };
+            let extended = unsafe { std::mem::transmute::<Node<'_>, Node<'static>>(node) };
             TreeSitterNode::new(extended, self)
         }
 

--- a/helix-core/src/extensions.rs
+++ b/helix-core/src/extensions.rs
@@ -1141,7 +1141,7 @@ Returns a new rope value.
             .register_fn(
                 "tssyntax->layers-byte-range",
                 |syn: TreeSitterSyntax, lower: u32, upper: u32| -> Vec<TreeSitterTree> {
-                    TreeSitterSyntax::get_trees_byte_range(&syn.get_inner(), lower, upper)
+                    TreeSitterSyntax::get_trees_byte_range(syn.get_inner(), lower, upper)
                 },
             )
             .register_fn("tssyntax->tree", TreeSitterSyntax::get_tree);

--- a/helix-core/src/extensions.rs
+++ b/helix-core/src/extensions.rs
@@ -115,10 +115,7 @@ pub mod steel_implementations {
                 ));
             };
 
-            let val = match (func.function)(&vec![lang.clone()]) {
-                Ok(f) => f,
-                Err(e) => return Err(e),
-            };
+            let val = (func.function)(&vec![lang.clone()])?;
 
             let SteelVal::Custom(custom) = val else {
                 return Ok(None);
@@ -198,13 +195,10 @@ pub mod steel_implementations {
                 let val = SteelVal::StringV(SteelString::from(
                     loader.language(lang).config().language_id.clone(),
                 ));
-                let loaded = match query_loader.load(&val) {
-                    Ok(l) => l,
-                    Err(e) => return Err(e),
-                };
 
-                if loaded.is_some() {
-                    query_map.insert(lang, loaded.unwrap());
+                let loaded = query_loader.load(&val)?;
+                if let Some(loaded) = loaded {
+                    query_map.insert(lang, loaded);
                 }
             }
             let mut captures: BTreeMap<String, Vec<TreeSitterNode>> = BTreeMap::new();

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -3635,14 +3635,11 @@ fn load_treesitter_api(engine: &mut Engine, generate_sources: bool) {
              lower: u32,
              upper: u32|
              -> Option<Vec<TreeSitterTree>> {
-                let Some(syn) = cx
+                let syn = cx
                     .editor
                     .documents
                     .get(&doc_id)
-                    .and_then(|d| d.syntax.as_ref())
-                else {
-                    return None;
-                };
+                    .and_then(|d| d.syntax.as_ref())?;
 
                 Some(TreeSitterSyntax::get_trees_byte_range(syn, lower, upper))
             },

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -3815,7 +3815,7 @@ fn load_treesitter_api(engine: &mut Engine, generate_sources: bool) {
         );
 
     if generate_sources {
-        generate_module("treesitter.scm", &builtin_treesitter_module);
+        generate_module("treesitter.scm", builtin_treesitter_module);
         configure_lsp_builtins("treesitter", &module);
     }
     engine.register_steel_module(
@@ -3904,7 +3904,7 @@ pub fn generate_cog_file() {
 pub fn load_ext_api(engine: &mut Engine, generate_sources: bool) {
     let ext_api = include_str!("ext.scm");
     if generate_sources {
-        generate_module("ext.scm", &ext_api);
+        generate_module("ext.scm", ext_api);
     }
     engine.register_steel_module("helix/ext.scm".to_string(), ext_api.to_string());
 }

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -3670,9 +3670,7 @@ fn load_treesitter_api(engine: &mut Engine, generate_sources: bool) {
              -> Option<Result<TreeSitterMatch, SteelErr>> {
                 let (text, syn) = {
                     let Some(doc) = cx.editor.documents.get(&doc_id) else {
-                        return Some(
-                            steelerr!(Generic => "unable to find doc, id: {}", doc_id).into(),
-                        );
+                        return Some(steelerr!(Generic => "unable to find doc, id: {}", doc_id));
                     };
                     let text = doc.text().slice(..);
                     let Some(syn) = doc.syntax() else {
@@ -3705,9 +3703,7 @@ fn load_treesitter_api(engine: &mut Engine, generate_sources: bool) {
              -> Option<Result<TreeSitterMatch, SteelErr>> {
                 let (text, syn) = {
                     let Some(doc) = cx.editor.documents.get(&doc_id) else {
-                        return Some(
-                            steelerr!(Generic => "unable to find doc, id: {}", doc_id).into(),
-                        );
+                        return Some(steelerr!(Generic => "unable to find doc, id: {}", doc_id));
                     };
                     let text = doc.text().slice(..);
                     let Some(syn) = doc.syntax() else {
@@ -3751,10 +3747,10 @@ fn load_treesitter_api(engine: &mut Engine, generate_sources: bool) {
          -> Result<TreeSitterQuery, SteelErr> {
             let loader = config.language_configuration.load();
             let Some(lang) = loader.language_for_name(language.to_string()) else {
-                return steelerr!(Generic => "unable to find language: {}", language).into();
+                return steelerr!(Generic => "unable to find language: {}", language);
             };
             let Some(config) = loader.get_config(lang) else {
-                return steelerr!(Generic => "unable to find language: {}", language).into();
+                return steelerr!(Generic => "unable to find language: {}", language);
             };
             TreeSitterQuery::new(config.grammar, source.as_str())
         },
@@ -3812,7 +3808,7 @@ fn load_treesitter_api(engine: &mut Engine, generate_sources: bool) {
              -> Result<TreeSitterSyntax, SteelErr> {
                 let loader = config.language_configuration.load();
                 let Some(lang) = loader.language_for_name(language.as_str()) else {
-                    return steelerr!(Generic => "unable to find language: {}", language).into();
+                    return steelerr!(Generic => "unable to find language: {}", language);
                 };
                 TreeSitterSyntax::new(source, lang, loader.as_ref())
             },


### PR DESCRIPTION
since new features have been added, most notably the tree-sitter stuff, new clippy warnings have surfaced, so fix them again to make merging easier on the maintainers when it's time.