### PR TITLE
feat(steel): add `editor->current-theme` to expose active theme

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -1323,7 +1323,8 @@ fn load_theme_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn("add-theme!", add_theme)
         .register_fn("theme-style", get_style)
         .register_fn("theme-set-style!", set_style)
-        .register_fn("string->color", string_to_color);
+        .register_fn("string->color", string_to_color)
+        .register_fn_with_ctx(CTX, "editor->current-theme", get_current_theme);
 
     if generate_sources {
         configure_lsp_builtins("themes", &module);
@@ -1390,6 +1391,10 @@ fn get_style(theme: &SteelTheme, name: SteelString) -> helix_view::theme::Style 
 
 fn set_style(theme: &mut SteelTheme, name: String, style: helix_view::theme::Style) {
     theme.0.set(name, style)
+}
+
+fn get_current_theme(cx: &mut Context) -> SteelTheme {
+    SteelTheme(cx.editor.theme.clone())
 }
 
 fn string_to_color(string: SteelString) -> Result<Color, anyhow::Error> {

--- a/helix-term/src/commands/engine/steel/themes.scm
+++ b/helix-term/src/commands/engine/steel/themes.scm
@@ -168,6 +168,7 @@
 
 (provide hashmap->theme
          register-theme
+         editor->current-theme
          theme-style
          theme-set-style!
          string->color)


### PR DESCRIPTION
   I was writing a plugin like [monaspace.nvim](https://github.com/jackplus-xyz/monaspace.nvim)
    but found there is no API to retrieve the current editor theme, making it impossible to patch an existing colorscheme with custom font modifiers while preserving its colors.

   This PR adds `editor->current-theme`, which clones the active theme as a `SteelTheme` so plugins can read/modify it:

   ```scheme
   (require "helix/themes.scm")
   (define theme (editor->current-theme))
   (displayln (theme-style theme "keyword"))       ;; read styles
   (theme-set-style! theme "keyword" new-style)    ;; modify the clone
   (register-theme theme)                          ;; register the patched theme
   ```
   
   I've tested it and can confirm it works as I expected.