### PR TITLE
Provide error message when the install script fails to call forge 

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -87,15 +87,23 @@ pub mod tasks {
         println!("----------------------------");
         println!("Warming up `forge`...");
 
-        std::process::Command::new("forge")
+        let forge = std::process::Command::new("forge")
             .args(["pkg", "refresh"])
             .spawn()
             .unwrap()
-            .wait()
-            .unwrap();
+            .wait();
 
-        println!("Done.");
-        println!("----------------------------");
+        match forge {
+            Ok(_) => {
+                println!("Done.");
+                println!("----------------------------");
+            }
+            Err(e) => {
+                println!("Error calling forge !!! Make sure that ~/.cargo/bin or $CARGO_HOME/bin are loaded into the path.");
+                println!("----------------------------");
+                panic!("{:?}", e)
+            }
+        }
 
         code_gen();
 


### PR DESCRIPTION
Add a short error message when the forge invocation fails even if everything else seemed correct. This one would've been very useful to me and I hope it is to others :)