### PR TITLE
Expose terminal focus events to Steel components

### DIFF
--- a/helix-term/src/commands/engine/steel/components.rs
+++ b/helix-term/src/commands/engine/steel/components.rs
@@ -441,6 +441,12 @@ pub fn helix_component_module(generate_sources: bool) -> BuiltInModule {
         )
         .register_fn("style", Style::default)
         .register_fn("Event?", |value: SteelVal| Event::as_ref(&value).is_ok())
+        .register_fn("focus-gained-event?", |event: Event| {
+            matches!(event, Event::FocusGained)
+        })
+        .register_fn("focus-lost-event?", |event: Event| {
+            matches!(event, Event::FocusLost)
+        })
         .register_fn("paste-event?", |event: Event| {
             matches!(event, Event::Paste(_))
         })

--- a/helix-term/src/commands/engine/steel/components.scm
+++ b/helix-term/src/commands/engine/steel/components.scm
@@ -1048,6 +1048,30 @@
 ;;
 (define Event? helix.components.Event?)
 
+(provide focus-gained-event?)
+;;@doc
+;;Checks if the given event is a focus gained event.
+;;
+;;```scheme
+;;(focus-gained-event? event) -> bool?
+;;```
+;;
+;;* event : Event?
+;;
+(define focus-gained-event? helix.components.focus-gained-event?)
+
+(provide focus-lost-event?)
+;;@doc
+;;Checks if the given event is a focus lost event.
+;;
+;;```scheme
+;;(focus-lost-event? event) -> bool?
+;;```
+;;
+;;* event : Event?
+;;
+(define focus-lost-event? helix.components.focus-lost-event?)
+
 (provide paste-event?)
 ;;@doc
 ;;Checks if the given event is a paste event.


### PR DESCRIPTION
## Summary
- add Steel component predicates for terminal focus gained/lost events
- export the helpers from the generated Scheme component API docs

## Motivation
Dynamic Steel components already receive compositor events, and the component API exposes predicates for key, mouse, and paste events. Focus events are delivered to components too, but Scheme code cannot currently distinguish them from other non-key events.

This adds the minimal predicates needed for focus-aware plugins without adding any user-specific behavior.

## Test
- nix develop --impure --option substituters 'https://cache.nixos.org https://helix.cachix.org' --option trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWGuG0ldV5j1Wn12JHITwN4v0M2dY= helix.cachix.org-1:ejp9KQpR1FBI2onstMQ34yogDm4OgU2ru6lIwPvuCVs=' -c env HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1 cargo check -p helix-term
- nix develop --impure --option substituters 'https://cache.nixos.org https://helix.cachix.org' --option trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWGuG0ldV5j1Wn12JHITwN4v0M2dY= helix.cachix.org-1:ejp9KQpR1FBI2onstMQ34yogDm4OgU2ru6lIwPvuCVs=' -c cargo fmt --check

## Example plugin
I used these predicates in a small Steel plugin:
https://github.com/mtul0729/helix-fcitx-focus

It keeps fcitx5 inactive in normal/select mode and restores the previous input method when entering insert mode. Installation uses Forge:

```sh
forge pkg install --git https://github.com/mtul0729/helix-fcitx-focus
```

Then load it from `~/.config/helix/init.scm`:

```scheme
(require "helix-fcitx-focus/cogs/fcitx-focus.scm")
```

The relevant Steel side combines `on-mode-switch` with terminal focus events:

```scheme
(register-hook 'on-mode-switch
  (lambda (event)
    (let ([old-mode (mode-switch-old event)]
          [new-mode (mode-switch-new event)])
      (cond
        [(and (insert-mode? old-mode) (not (insert-mode? new-mode)))
         (fcitx-save-and-close)]
        [(and (not (insert-mode? old-mode)) (insert-mode? new-mode))
         (fcitx-restore)]))))

(define (handle-fcitx-focus-event _ event)
  (cond
    [(focus-gained-event? event)
     (close-or-restore-fcitx)
     event-result/ignore]
    [(and (focus-lost-event? event) (insert-mode? (editor-mode)))
     (fcitx-save)
     event-result/ignore]
    [else event-result/ignore]))

(push-component!
  (new-component!
    "fcitx-focus"
    #f
    #f
    (hash "handle_event" handle-fcitx-focus-event)))
```
