### PR TITLE
Expose terminal focus through Steel hooks

### DIFF
--- a/helix-term/src/commands/engine/steel/editor.scm
+++ b/helix-term/src/commands/engine/steel/editor.scm
@@ -18,6 +18,8 @@
 ;; * 'on-mode-switch
 ;; * 'post-insert-char
 ;; * 'post-command
+;; * 'terminal-focus-gained
+;; * 'terminal-focus-lost
 ;; * 'document-focus-lost
 ;; * 'selection-did-change
 ;; * 'document-opened
@@ -54,6 +56,24 @@
 ;; ```scheme
 ;; (register-hook 'post-command
 ;;                (lambda (command-name) (log::info! command-name)))
+;; ```
+;;
+;; ## terminal-focus-gained
+;;
+;; Expects a function with no arguments.
+;;
+;; ```scheme
+;; (register-hook 'terminal-focus-gained
+;;                (lambda () (log::info! "terminal focus gained")))
+;; ```
+;;
+;; ## terminal-focus-lost
+;;
+;; Expects a function with no arguments.
+;;
+;; ```scheme
+;; (register-hook 'terminal-focus-lost
+;;                (lambda () (log::info! "terminal focus lost")))
 ;; ```
 ;;
 ;; ## document-focus-lost

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -78,7 +78,7 @@ use crate::{
     commands::{insert, TYPABLE_COMMAND_LIST},
     compositor::{self, Component, Compositor},
     config::Config,
-    events::{OnModeSwitch, PostCommand, PostInsertChar},
+    events::{OnModeSwitch, PostCommand, PostInsertChar, TerminalFocusGained, TerminalFocusLost},
     job::{self, Callback, Jobs},
     keymap::{self, merge_keys, KeyTrie, KeymapResult, MappableCommand},
     ui::{self, picker::PathOrId, PickerColumn, Popup, Prompt, PromptEvent},
@@ -3312,6 +3312,8 @@ fn register_hook(event_kind: String, callback_fn: SteelVal) -> steel::UnRecovera
         "post-insert-char" => register_post_insert_char(generation, rooted),
         // Register hook - on save?
         "post-command" => register_post_command(generation, rooted),
+        "terminal-focus-gained" => register_terminal_focus_gained(generation, rooted),
+        "terminal-focus-lost" => register_terminal_focus_lost(generation, rooted),
         "document-focus-lost" => register_document_focus_lost(generation, rooted),
         "selection-did-change" => register_selection_did_change(generation, rooted),
         "document-opened" => register_document_opened(generation, rooted),
@@ -3536,6 +3538,30 @@ fn register_on_mode_switch(
             &mut [minimized_event.into_steelval().unwrap()],
         );
 
+        Ok(())
+    });
+
+    Ok(SteelVal::Void).into()
+}
+
+fn register_terminal_focus_gained(
+    generation: usize,
+    rooted: RootedSteelVal,
+) -> steel::UnRecoverableResult {
+    register_hook!(move |event: &mut TerminalFocusGained<'_, '_>| {
+        generation_call_with_args(generation, event.cx, rooted.value().clone(), &mut []);
+        Ok(())
+    });
+
+    Ok(SteelVal::Void).into()
+}
+
+fn register_terminal_focus_lost(
+    generation: usize,
+    rooted: RootedSteelVal,
+) -> steel::UnRecoverableResult {
+    register_hook!(move |event: &mut TerminalFocusLost<'_, '_>| {
+        generation_call_with_args(generation, event.cx, rooted.value().clone(), &mut []);
         Ok(())
     });
 

--- a/helix-term/src/events.rs
+++ b/helix-term/src/events.rs
@@ -13,12 +13,16 @@ events! {
     OnModeSwitch<'a, 'cx> { old_mode: Mode, new_mode: Mode, cx: &'a mut commands::Context<'cx> }
     PostInsertChar<'a, 'cx> { c: char, cx: &'a mut commands::Context<'cx> }
     PostCommand<'a, 'cx> { command: & 'a MappableCommand, cx: &'a mut commands::Context<'cx> }
+    TerminalFocusGained<'a, 'cx> { cx: &'a mut commands::Context<'cx> }
+    TerminalFocusLost<'a, 'cx> { cx: &'a mut commands::Context<'cx> }
 }
 
 pub fn register() {
     register_event::<OnModeSwitch>();
     register_event::<PostInsertChar>();
     register_event::<PostCommand>();
+    register_event::<TerminalFocusGained>();
+    register_event::<TerminalFocusLost>();
     register_event::<DocumentDidOpen>();
     register_event::<DocumentDidChange>();
     register_event::<DocumentDidClose>();

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1,7 +1,7 @@
 use crate::{
     commands::{self, engine::ScriptingEngine, OnKeyCallback, OnKeyCallbackKind},
     compositor::{Component, Context, Event, EventResult},
-    events::{OnModeSwitch, PostCommand},
+    events::{OnModeSwitch, PostCommand, TerminalFocusGained, TerminalFocusLost},
     handlers::completion::CompletionItem,
     key,
     keymap::{KeymapResult, Keymaps},
@@ -1580,10 +1580,12 @@ impl Component for EditorView {
             Event::Mouse(event) => self.handle_mouse_event(event, &mut cx),
             Event::IdleTimeout => self.handle_idle_timeout(&mut cx),
             Event::FocusGained => {
+                helix_event::dispatch(TerminalFocusGained { cx: &mut cx });
                 self.terminal_focused = true;
                 EventResult::Consumed(None)
             }
             Event::FocusLost => {
+                helix_event::dispatch(TerminalFocusLost { cx: &mut cx });
                 if context.editor.config().auto_save.focus_lost {
                     let options = commands::WriteAllOptions {
                         force: false,


### PR DESCRIPTION
## Summary
- add Steel register-hook entries for terminal focus gained/lost events
- dispatch terminal focus events from the editor event path
- document the new terminal focus hooks in the generated Scheme API docs

## Motivation
#111 exposed terminal focus events to Steel dynamic components. That remains useful for components which already participate in the compositor stack and need to react from handle_event.

This PR adds a non-UI entry point for the same terminal focus signal through register-hook: terminal-focus-gained and terminal-focus-lost.

Some Steel plugins only need to observe terminal focus as session-level state. Creating a non-visual dynamic component works, but it unnecessarily participates in the compositor stack. A hook keeps that use case out of UI layering while preserving the component event path added in #111.

## Validation plugin
I tested this with helix-fcitx-focus:
https://github.com/mtul0729/helix-fcitx-focus

That plugin previously combined on-mode-switch with a non-visual dynamic component to observe terminal focus. With these hooks, it can stay entirely in the hook API and avoid adding a background listener to the compositor stack.

## Test
- cargo fmt --check
- cargo check -p helix-term
- manually tested the patched Helix with helix-fcitx-focus migrated to terminal-focus-gained / terminal-focus-lost hooks