### PR TITLE
Refresh file events after Steel document reload

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -1480,10 +1480,17 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
             CTX,
             "editor-document-reload",
             |cx: &mut Context, doc: DocumentId| -> anyhow::Result<()> {
+                let path = cx.editor.documents.get(&doc).and_then(|x| x.path().cloned());
                 for (view, _) in cx.editor.tree.views_mut() {
                     if let Some(x) = cx.editor.documents.get_mut(&doc) {
                         x.reload(view, &cx.editor.diff_providers)?;
                     }
+                }
+                if let Some(path) = path {
+                    cx.editor
+                        .language_servers
+                        .file_event_handler
+                        .file_changed(path);
                 }
                 Ok(())
             },


### PR DESCRIPTION
## Summary

- make the Steel `editor-document-reload` API notify Helix file event handling after reloading a document
- align Steel-triggered reload behavior more closely with the typed `:reload` command

## Validation

- `nix build .#helix --no-link`
