### PR TITLE
fix: dont panic when fail to write file

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -60,17 +60,17 @@ use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
     error::Error,
+    fs,
     io::Write,
     num::{NonZeroU8, NonZeroUsize},
     ops::{Deref, DerefMut},
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
-        Mutex, MutexGuard, RwLock, RwLockReadGuard, Weak,
+        Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, Weak,
     },
     time::{Duration, SystemTime},
 };
-use std::{str::FromStr as _, sync::Arc};
 
 use steel::{rvals::Custom, steel_vm::builtin::BuiltInModule};
 
@@ -3975,12 +3975,18 @@ pub fn alternative_runtime_search_path() -> Option<PathBuf> {
 
 pub fn generate_cog_file() {
     if let Some(path) = alternative_runtime_search_path() {
-        std::fs::write(
-            path.join("cog.scm"),
-            r#"(define package-name 'helix)
-            (define version "0.1.0")"#,
-        )
-        .unwrap();
+        let cog_scm_path = path.join("cog.scm");
+        if fs::exists(cog_scm_path) {
+            log::info!("using pre-existing cog.scm file");
+        } else {
+            if let Err(e) = fs::write(
+                cog_scm_path,
+                r#"(define package-name 'helix)
+                (define version "0.1.0")"#,
+            ) {
+                log::warn!("error writing cog.scm file: {}", e);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I use NixOs, and the way I configure my system make the `STEEL_HOME` dir immutable, i.e. nothing there can be modified. However, I have already placed the file there myself so there is no need to write the file again, or panic if the file cannot be written.

Ofc this would create file content mismatch if the content were updated, but there is a log line there and I'm responsible for what I'm doing so I think it's sufficient.