### PR TITLE
Add DocumentFocusGained and ViewportChanged events with Steel hooks

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -309,6 +309,46 @@ impl Application {
 
         // TODO: need to recalculate view tree if necessary
 
+        // Detect viewport changes and dispatch ViewportChanged at most once
+        // per view per frame.  We use a two-pass collect to satisfy the
+        // borrow checker (can't hold &mut View and &Document at the same time
+        // through the tree iterator).  Running this after autoresize() ensures
+        // the snapshot reflects post-resize geometry, so height changes are not
+        // lagged by one frame.
+        {
+            use helix_view::events::ViewportChanged;
+            // Pass 1: collect what each view currently looks like.
+            let mut snapshot: Vec<(helix_view::ViewId, helix_view::DocumentId, usize, u16)> =
+                Vec::new();
+            for (view, _) in cx.editor.tree.views() {
+                let doc_id = view.doc;
+                if let Some(doc) = cx.editor.documents.get(&doc_id) {
+                    let anchor = doc.view_offset(view.id).anchor;
+                    let height = view.inner_area(doc).height;
+                    snapshot.push((view.id, doc_id, anchor, height));
+                }
+            }
+            // Pass 2: compare against last-seen values; dispatch if changed.
+            let mut to_dispatch: Vec<(helix_view::ViewId, helix_view::DocumentId, usize, u16)> =
+                Vec::new();
+            for &(view_id, doc_id, anchor, height) in &snapshot {
+                let view = cx.editor.tree.get_mut(view_id);
+                if anchor != view.last_viewport_anchor || height != view.last_viewport_height {
+                    view.last_viewport_anchor = anchor;
+                    view.last_viewport_height = height;
+                    to_dispatch.push((view_id, doc_id, anchor, height));
+                }
+            }
+            for (view_id, doc_id, anchor_char_idx, height) in to_dispatch {
+                helix_event::dispatch(ViewportChanged {
+                    view_id,
+                    doc_id,
+                    anchor_char_idx,
+                    height,
+                });
+            }
+        }
+
         let surface = self.terminal.current_buffer_mut();
 
         self.compositor.render(area, surface, &mut cx);

--- a/helix-term/src/commands/engine/steel/editor.scm
+++ b/helix-term/src/commands/engine/steel/editor.scm
@@ -22,6 +22,7 @@
 ;; * 'terminal-focus-lost
 ;; * 'document-focus-lost
 ;; * 'document-focus-gained
+;; * 'viewport-changed
 ;; * 'selection-did-change
 ;; * 'document-opened
 ;; * 'document-saved
@@ -84,6 +85,19 @@
 ;; ## document-focus-gained
 ;;
 ;; Expects a function with one argument to accept the doc id of the document that has gained focus.
+;;
+;; ## viewport-changed
+;;
+;; Expects a function with four arguments: the view id, the doc id, the anchor
+;; (char index of the first visible character) and the viewport height in rows.
+;; Fired at most once per view per frame, whenever the viewport anchor or
+;; height changes - e.g. on scroll or resize.
+;;
+;; ```scheme
+;; (register-hook 'viewport-changed
+;;                (lambda (view-id doc-id anchor height)
+;;                  (log::info! (to-string view-id doc-id anchor height))))
+;; ```
 ;;
 ;; ## selection-did-change
 ;;

--- a/helix-term/src/commands/engine/steel/editor.scm
+++ b/helix-term/src/commands/engine/steel/editor.scm
@@ -21,6 +21,7 @@
 ;; * 'terminal-focus-gained
 ;; * 'terminal-focus-lost
 ;; * 'document-focus-lost
+;; * 'document-focus-gained
 ;; * 'selection-did-change
 ;; * 'document-opened
 ;; * 'document-saved
@@ -79,6 +80,10 @@
 ;; ## document-focus-lost
 ;;
 ;; Expects a function with one argument to accept the doc id of the document that has lost focus.
+;;
+;; ## document-focus-gained
+;;
+;; Expects a function with one argument to accept the doc id of the document that has gained focus.
 ;;
 ;; ## selection-did-change
 ;;

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -33,7 +33,7 @@ use helix_view::{
     },
     events::{
         DocumentDidChange, DocumentDidClose, DocumentDidOpen, DocumentFocusGained,
-        DocumentFocusLost, DocumentSaved, SelectionDidChange,
+        DocumentFocusLost, DocumentSaved, SelectionDidChange, ViewportChanged,
     },
     extension::document_id_to_usize,
     graphics::CursorKind,
@@ -3323,6 +3323,7 @@ fn register_hook(event_kind: String, callback_fn: SteelVal) -> steel::UnRecovera
         "terminal-focus-lost" => register_terminal_focus_lost(generation, rooted),
         "document-focus-lost" => register_document_focus_lost(generation, rooted),
         "document-focus-gained" => register_document_focus_gained(generation, rooted),
+        "viewport-changed" => register_viewport_changed(generation, rooted),
         "selection-did-change" => register_selection_did_change(generation, rooted),
         "document-opened" => register_document_opened(generation, rooted),
         "document-saved" => register_document_saved(generation, rooted),
@@ -3507,6 +3508,33 @@ fn register_document_focus_gained(
         let doc_id = event.doc;
         let callback =
             construct_callback(generation, cloned_func, [doc_id.into_steelval().unwrap()]);
+        job::dispatch_blocking_jobs(callback);
+
+        Ok(())
+    });
+    Ok(SteelVal::Void).into()
+}
+
+fn register_viewport_changed(
+    generation: usize,
+    rooted: RootedSteelVal,
+) -> steel::UnRecoverableResult {
+    register_hook!(move |event: &mut ViewportChanged| {
+        let cloned_func = rooted.value().clone();
+        let view_id = event.view_id;
+        let doc_id = event.doc_id;
+        let anchor = event.anchor_char_idx;
+        let height = event.height;
+        let callback = construct_callback(
+            generation,
+            cloned_func,
+            [
+                view_id.into_steelval().unwrap(),
+                doc_id.into_steelval().unwrap(),
+                (anchor as i64).into_steelval().unwrap(),
+                (height as i64).into_steelval().unwrap(),
+            ],
+        );
         job::dispatch_blocking_jobs(callback);
 
         Ok(())

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -32,8 +32,8 @@ use helix_view::{
         WhitespaceRender, WhitespaceRenderValue,
     },
     events::{
-        DocumentDidChange, DocumentDidClose, DocumentDidOpen, DocumentFocusLost, DocumentSaved,
-        SelectionDidChange,
+        DocumentDidChange, DocumentDidClose, DocumentDidOpen, DocumentFocusGained,
+        DocumentFocusLost, DocumentSaved, SelectionDidChange,
     },
     extension::document_id_to_usize,
     graphics::CursorKind,
@@ -3322,6 +3322,7 @@ fn register_hook(event_kind: String, callback_fn: SteelVal) -> steel::UnRecovera
         "terminal-focus-gained" => register_terminal_focus_gained(generation, rooted),
         "terminal-focus-lost" => register_terminal_focus_lost(generation, rooted),
         "document-focus-lost" => register_document_focus_lost(generation, rooted),
+        "document-focus-gained" => register_document_focus_gained(generation, rooted),
         "selection-did-change" => register_selection_did_change(generation, rooted),
         "document-opened" => register_document_opened(generation, rooted),
         "document-saved" => register_document_saved(generation, rooted),
@@ -3486,6 +3487,22 @@ fn register_document_focus_lost(
     // is probably the most helpful so that way we can look the document up
     // and act accordingly?
     register_hook!(move |event: &mut DocumentFocusLost<'_>| {
+        let cloned_func = rooted.value().clone();
+        let doc_id = event.doc;
+        let callback =
+            construct_callback(generation, cloned_func, [doc_id.into_steelval().unwrap()]);
+        job::dispatch_blocking_jobs(callback);
+
+        Ok(())
+    });
+    Ok(SteelVal::Void).into()
+}
+
+fn register_document_focus_gained(
+    generation: usize,
+    rooted: RootedSteelVal,
+) -> steel::UnRecoverableResult {
+    register_hook!(move |event: &mut DocumentFocusGained<'_>| {
         let cloned_func = rooted.value().clone();
         let doc_id = event.doc;
         let callback =

--- a/helix-term/src/events.rs
+++ b/helix-term/src/events.rs
@@ -2,8 +2,8 @@ use helix_event::{events, register_event};
 use helix_view::document::Mode;
 use helix_view::events::{
     ConfigDidChange, DiagnosticsDidChange, DocumentDidChange, DocumentDidClose, DocumentDidOpen,
-    DocumentFocusLost, DocumentSaved, LanguageServerExited, LanguageServerInitialized,
-    SelectionDidChange,
+    DocumentFocusGained, DocumentFocusLost, DocumentSaved, LanguageServerExited,
+    LanguageServerInitialized, SelectionDidChange,
 };
 
 use crate::commands;
@@ -27,6 +27,7 @@ pub fn register() {
     register_event::<DocumentDidChange>();
     register_event::<DocumentDidClose>();
     register_event::<DocumentFocusLost>();
+    register_event::<DocumentFocusGained>();
     register_event::<DocumentSaved>();
     register_event::<SelectionDidChange>();
     register_event::<DiagnosticsDidChange>();

--- a/helix-term/src/events.rs
+++ b/helix-term/src/events.rs
@@ -3,7 +3,7 @@ use helix_view::document::Mode;
 use helix_view::events::{
     ConfigDidChange, DiagnosticsDidChange, DocumentDidChange, DocumentDidClose, DocumentDidOpen,
     DocumentFocusGained, DocumentFocusLost, DocumentSaved, LanguageServerExited,
-    LanguageServerInitialized, SelectionDidChange,
+    LanguageServerInitialized, SelectionDidChange, ViewportChanged,
 };
 
 use crate::commands;
@@ -29,6 +29,7 @@ pub fn register() {
     register_event::<DocumentFocusLost>();
     register_event::<DocumentFocusGained>();
     register_event::<DocumentSaved>();
+    register_event::<ViewportChanged>();
     register_event::<SelectionDidChange>();
     register_event::<DiagnosticsDidChange>();
     register_event::<LanguageServerInitialized>();

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -4,7 +4,9 @@ use crate::{
     document::{
         DocumentOpenError, DocumentSavedEventFuture, DocumentSavedEventResult, Mode, SavePoint,
     },
-    events::{DocumentDidClose, DocumentDidOpen, DocumentFocusLost, DocumentSaved},
+    events::{
+        DocumentDidClose, DocumentDidOpen, DocumentFocusGained, DocumentFocusLost, DocumentSaved,
+    },
     graphics::{CursorKind, Rect},
     handlers::Handlers,
     info::Info,
@@ -1854,6 +1856,10 @@ impl Editor {
                     editor: self,
                     doc: id,
                 });
+                dispatch(DocumentFocusGained {
+                    editor: self,
+                    doc: id,
+                });
                 return;
             }
             Action::Load => {
@@ -1893,6 +1899,10 @@ impl Editor {
             dispatch(DocumentFocusLost {
                 editor: self,
                 doc: focus_lost,
+            });
+            dispatch(DocumentFocusGained {
+                editor: self,
+                doc: id,
             });
         }
     }
@@ -2149,9 +2159,14 @@ impl Editor {
         doc_mut!(self).mark_as_focused();
 
         let focus_lost = self.tree.get(prev_id).doc;
+        let focus_gained = self.tree.get(view_id).doc;
         dispatch(DocumentFocusLost {
             editor: self,
             doc: focus_lost,
+        });
+        dispatch(DocumentFocusGained {
+            editor: self,
+            doc: focus_gained,
         });
     }
 
@@ -2475,6 +2490,10 @@ impl Editor {
             dispatch(DocumentFocusLost {
                 editor: self,
                 doc: old_doc_id,
+            });
+            dispatch(DocumentFocusGained {
+                editor: self,
+                doc: dest_doc_id,
             });
         }
         let (view, doc) = current!(self);

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -27,6 +27,13 @@ events! {
     // called **after** a document gains focus (but not when it is first opened)
     DocumentFocusGained<'a> { editor: &'a mut Editor, doc: DocumentId }
     DocumentSaved<'a> { editor: &'a mut Editor, doc: DocumentId }
+    // fired at most once per view per frame when the viewport anchor or height changes
+    ViewportChanged {
+        view_id: ViewId,
+        doc_id: DocumentId,
+        anchor_char_idx: usize,
+        height: u16
+    }
 
     LanguageServerInitialized<'a> {
         editor: &'a mut Editor,

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -24,6 +24,8 @@ events! {
     DiagnosticsDidChange<'a> { editor: &'a mut Editor, doc: DocumentId }
     // called **after** a document loses focus (but not when its closed)
     DocumentFocusLost<'a> { editor: &'a mut Editor, doc: DocumentId }
+    // called **after** a document gains focus (but not when it is first opened)
+    DocumentFocusGained<'a> { editor: &'a mut Editor, doc: DocumentId }
     DocumentSaved<'a> { editor: &'a mut Editor, doc: DocumentId }
 
     LanguageServerInitialized<'a> {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -157,6 +157,10 @@ pub struct View {
     // left to future work. For now we treat all views as focused and give them
     // each their own handler.
     pub diagnostics_handler: DiagnosticsHandler,
+    /// Last known anchor char-index, used to detect anchor changes at drain time.
+    pub last_viewport_anchor: usize,
+    /// Last known inner height, used to detect height changes at drain time.
+    pub last_viewport_height: u16,
 }
 
 impl fmt::Debug for View {
@@ -182,6 +186,8 @@ impl View {
             gutters,
             doc_revisions: HashMap::new(),
             diagnostics_handler: DiagnosticsHandler::new(),
+            last_viewport_anchor: 0,
+            last_viewport_height: 0,
         }
     }
 


### PR DESCRIPTION
## Summary
- add a `DocumentFocusGained` event, dispatched symmetrically with the existing `DocumentFocusLost` in `Editor::switch`, `Editor::focus` and `Editor::jump_to`, exposed through a `'document-focus-gained` register-hook entry
- add a `ViewportChanged` event that fires at most once per view per frame when the viewport anchor or height changes, exposed through a `'viewport-changed` register-hook entry
- document both hooks in the generated Scheme API docs (`editor.scm`), following the terminal-focus precedent from #112

## Motivation
#111 and #112 exposed *terminal*-level focus to Steel. This PR extends the same idea to per-document granularity and to scroll position.

The driving use case is a plugin that renders content tied to specific buffers and screen regions (in my case, inline image/animation rendering): it needs to pause work for a document the moment the user switches away and resume it when they come back, and it needs to know when the visible window over a document moves so it can lazy-render only what is on screen and stop spending cycles on offscreen content.

`document-focus-lost` already exists as a hook, but without its counterpart a plugin can only infer "focus gained" indirectly (e.g. polling `editor-focus` from other hooks). `document-focus-gained` completes the pair: the callback receives the doc id of the newly focused document, mirroring the focus-lost callback.

For scroll, there is currently no event at all — plugins would have to poll the view offset on a timer or piggyback on `selection-did-change` (which doesn't fire for scrolloff-free scrolling like `C-d`/`mouse wheel`, and fires far too often for everything else).

## Design notes
- `DocumentFocusGained` is dispatched immediately after `DocumentFocusLost` at each of its existing dispatch sites (both branches of `Editor::switch`, plus `Editor::focus` and `Editor::jump_to`), so the lost/gained ordering a plugin observes is always "lost old, gained new". It is intentionally *not* fired when a document is first opened — `document-opened` already covers that, matching the doc comment on `DocumentFocusLost` ("but not when its closed").
- `ViewportChanged` is coalesced per frame rather than dispatched from every scroll call site. The render loop snapshots each view's anchor (`doc.view_offset(view.id).anchor`) and inner height right after `autoresize()` and compares them against last-seen values stored on the `View` (`last_viewport_anchor` / `last_viewport_height`). Comparison at drain time was chosen over intercepting `set_view_offset` because `ViewPosition` is stored per-view *on the Document*, so there is no single choke point; this also picks up height changes from terminal resizes and split changes for free, and guarantees the at-most-once-per-frame rate limit no matter how many times a view scrolls between frames.
- `ViewportChanged` is the first event in `helix-view/src/events.rs` without a lifetime — it carries an owned payload (`view_id`, `doc_id`, `anchor_char_idx`, `height`) instead of `&mut Editor`, because it is dispatched from `Application::render` where the editor is already mutably borrowed. The Steel callback gets `(view-id doc-id anchor height)` and can reach the editor through `*helix.cx*` as usual since hook callbacks run via `dispatch_blocking_jobs`.
- The two-pass collect in `render()` is there for the borrow checker: the tree iterator hands out `&View` while we also need `&Document` for `inner_area`, then `&mut View` to update the last-seen values.

## Test
- `cargo check --workspace`
- `cargo test -p helix-view --lib` and `cargo test -p helix-term --lib`
- `cargo fmt --check` (the one remaining diff it reports, in `editor-document-reload`, pre-exists on the base branch and is untouched here)
- manually exercised in my fork: an inline-rendering plugin uses `'document-focus-gained` to resume per-document work and `'viewport-changed` to lazy-render visible content and pause offscreen animations while scrolling

## Things reviewers may want to weigh in on
- The viewport snapshot runs once per `render()` over all views. It is O(open views) with two small `Vec` allocations per frame; view counts are tiny in practice, but if the allocations bother you the two passes can be fused with a little index bookkeeping.
- When two views show the *same* document, `Editor::focus` will dispatch focus-lost and focus-gained with the same doc id. This mirrors the existing `DocumentFocusLost` behavior (which already fires in that case), so I kept the semantics symmetric rather than special-casing it — but I'm happy to suppress the pair when the doc id is unchanged if preferred.
- `anchor_char_idx` exposes the anchor as a raw char index. That's the natural unit on the Rust side and easy to feed back into rope APIs from Steel, but it does mean plugins that want a line number must convert via the document rope.
- `last_viewport_anchor`/`last_viewport_height` initialize to 0/0 in `View::new`, so `'viewport-changed` fires once per view on its first rendered frame even without scrolling. I'd call that a feature (plugins get an initial viewport report instead of waiting for the first scroll), but it's easy to suppress if you'd rather it stay quiet until a real change.
- While extracting this I noticed the existing `Action::Replace` arm of `Editor::switch` appears to dispatch `DocumentFocusLost` with the *new* doc id rather than the outgoing one. This PR mirrors the site as-is to stay minimal; happy to fix that here or in a separate PR if you confirm it's a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
