### PR TITLE
Harden Steel FFI functions against missing views and uncommitted async edits

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -1951,23 +1951,21 @@ impl SteelScriptingEngine {
         cx: &mut Context,
         event: KeyEvent,
     ) -> Option<KeymapResult> {
-        let extension = {
-            let current_focus = cx.editor.tree.focus;
-            let view = cx.editor.tree.get(current_focus);
-            let doc = &view.doc;
-            let current_doc = cx.editor.documents.get(doc);
+        let current_focus = cx.editor.tree.focus;
+        let view = match cx.editor.tree.try_get(current_focus) {
+            Some(v) => v,
+            None => return None,
+        };
 
+        let extension = {
+            let current_doc = cx.editor.documents.get(&view.doc);
             current_doc
                 .and_then(|x| x.path())
                 .and_then(|x| x.extension())
                 .and_then(|x| x.to_str())
         };
 
-        let doc_id = {
-            let current_focus = cx.editor.tree.focus;
-            let view = cx.editor.tree.get(current_focus);
-            &view.doc
-        };
+        let doc_id = &view.doc;
 
         if let Some(extension) = extension {
             let map = get_extension_keymap();
@@ -4700,38 +4698,39 @@ fn get_init_scm_path() -> String {
 // TODO:
 fn current_path(cx: &mut Context) -> Option<String> {
     let current_focus = cx.editor.tree.focus;
-    let view = cx.editor.tree.get(current_focus);
-    let doc = &view.doc;
-    // Lifetime of this needs to be tied to the existing document
-    let current_doc = cx.editor.documents.get(doc);
-    current_doc.and_then(|x| x.path().and_then(|x| x.to_str().map(|x| x.to_string())))
+    let view = cx.editor.tree.try_get(current_focus)?;
+    let current_doc = cx.editor.documents.get(&view.doc)?;
+    current_doc
+        .path()
+        .and_then(|x| x.to_str().map(|x| x.to_string()))
 }
 
 fn set_scratch_buffer_name(cx: &mut Context, name: String) {
     let current_focus = cx.editor.tree.focus;
-    let view = cx.editor.tree.get(current_focus);
-    let doc = &view.doc;
-    // Lifetime of this needs to be tied to the existing document
-    let current_doc = cx.editor.documents.get_mut(doc);
-
-    if let Some(current_doc) = current_doc {
-        current_doc.name = Some(name);
+    if let Some(view) = cx.editor.tree.try_get(current_focus) {
+        if let Some(current_doc) = cx.editor.documents.get_mut(&view.doc) {
+            current_doc.name = Some(name);
+        }
     }
 }
 
 fn set_buffer_uri(cx: &mut Context, uri: SteelString) -> anyhow::Result<()> {
     let current_focus = cx.editor.tree.focus;
-    let view = cx.editor.tree.get(current_focus);
-    let doc = &view.doc;
-    // Lifetime of this needs to be tied to the existing document
-    let current_doc = cx.editor.documents.get_mut(doc);
+    let view = cx
+        .editor
+        .tree
+        .try_get(current_focus)
+        .ok_or_else(|| anyhow::anyhow!("No active view"))?;
+    let current_doc = cx
+        .editor
+        .documents
+        .get_mut(&view.doc)
+        .ok_or_else(|| anyhow::anyhow!("No active document"))?;
 
-    if let Some(current_doc) = current_doc {
-        if let Ok(url) = url::Url::from_str(uri.as_str()) {
-            current_doc.uri = Some(Box::new(url));
-        } else {
-            anyhow::bail!("Unable to parse uri: {:?}", uri);
-        }
+    if let Ok(url) = url::Url::from_str(uri.as_str()) {
+        current_doc.uri = Some(Box::new(url));
+    } else {
+        anyhow::bail!("Unable to parse uri: {:?}", uri);
     }
 
     Ok(())
@@ -4741,8 +4740,8 @@ fn cx_current_focus(cx: &mut Context) -> helix_view::ViewId {
     cx.editor.tree.focus
 }
 
-fn cx_get_document_id(cx: &mut Context, view_id: helix_view::ViewId) -> DocumentId {
-    cx.editor.tree.get(view_id).doc
+fn cx_get_document_id(cx: &mut Context, view_id: helix_view::ViewId) -> Option<DocumentId> {
+    cx.editor.tree.try_get(view_id).map(|v| v.doc)
 }
 
 fn document_id_to_text(cx: &mut Context, doc_id: DocumentId) -> Option<SteelRopeSlice> {
@@ -5410,11 +5409,8 @@ pub fn add_inlay_hint(
     completion: SteelString,
 ) -> Option<(usize, usize)> {
     let view_id = cx.editor.tree.focus;
-    if !cx.editor.tree.contains(view_id) {
-        return None;
-    }
-    let view = cx.editor.tree.get(view_id);
-    let doc_id = cx.editor.tree.get(view_id).doc;
+    let view = cx.editor.tree.try_get(view_id)?;
+    let doc_id = view.doc;
     let doc = cx.editor.documents.get_mut(&doc_id)?;
     let mut new_inlay_hints = doc.inlay_hints(view_id).cloned().unwrap_or_else(|| {
         let doc_text = doc.text();
@@ -5455,11 +5451,8 @@ pub fn remove_inlay_hint_by_id(
 ) -> Option<()> {
     // let text = completion.to_string();
     let view_id = cx.editor.tree.focus;
-    if !cx.editor.tree.contains(view_id) {
-        return None;
-    }
-    let view = cx.editor.tree.get(view_id);
-    let doc_id = cx.editor.tree.get(view_id).doc;
+    let view = cx.editor.tree.try_get(view_id)?;
+    let doc_id = view.doc;
     let doc = cx.editor.documents.get_mut(&doc_id)?;
 
     let inlay_hints = doc.inlay_hints(view_id)?;
@@ -5500,10 +5493,10 @@ pub fn remove_inlay_hint_by_id(
 pub fn remove_inlay_hint(cx: &mut Context, char_index: usize, _completion: SteelString) -> bool {
     // let text = completion.to_string();
     let view_id = cx.editor.tree.focus;
-    if !cx.editor.tree.contains(view_id) {
-        return false;
-    }
-    let doc_id = cx.editor.tree.get_mut(view_id).doc;
+    let doc_id = match cx.editor.tree.try_get(view_id) {
+        Some(view) => view.doc,
+        None => return false,
+    };
     let doc = match cx.editor.documents.get_mut(&doc_id) {
         Some(x) => x,
         None => return false,

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -638,6 +638,7 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
     module
         .register_fn_with_ctx(CTX, "insert_char", insert_char)
         .register_fn_with_ctx(CTX, "insert_string", insert_string)
+        .register_fn_with_ctx(CTX, "commit-changes-to-history", commit_changes_to_history)
         .register_fn_with_ctx(CTX, "set-current-selection-object!", set_selection)
         .register_fn_with_ctx(CTX, "push-range-to-selection!", push_range_to_selection)
         .register_fn_with_ctx(
@@ -5524,4 +5525,13 @@ pub fn insert_string(cx: &mut Context, string: SteelString) {
         indent,
     );
     doc.apply(&transaction, view.id);
+}
+
+/// Commit any pending document changes to the undo history.
+/// This must be called after document modifications in async callbacks
+/// to prevent selection tracking crashes when EditorView::handle_event
+/// tries to commit stale changes.
+pub fn commit_changes_to_history(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    doc.append_changes_to_history(view);
 }

--- a/helix-term/src/commands/engine/steel/static.scm
+++ b/helix-term/src/commands/engine/steel/static.scm
@@ -13,6 +13,13 @@
 ;;Insert a given string at the current cursor position
 (define insert_string helix.static.insert_string)
 
+(provide commit-changes-to-history)
+;;@doc
+;;Commit any pending document changes to the undo history. Call this after
+;;modifying the document from an async callback to keep selection tracking
+;;consistent with the undo history.
+(define commit-changes-to-history helix.static.commit-changes-to-history)
+
 (provide set-current-selection-object!)
 ;;@doc
 ;;Update the selection object to the current selection within the editor

--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -298,7 +298,26 @@ impl Tree {
     ///
     /// Panics if `index` is not in self.nodes, or if the node's content is not [Content::View]. This can be checked with [Self::contains].
     pub fn get(&self, index: ViewId) -> &View {
-        self.try_get(index).unwrap()
+        // Distinguish the two failure modes up front so crashes report
+        // which case they hit (stale id vs container node) instead of
+        // landing on a bare `unwrap() on a None value`.
+        match self.nodes.get(index) {
+            Some(Node {
+                content: Content::View(view),
+                ..
+            }) => view,
+            Some(Node {
+                content: Content::Container(_),
+                ..
+            }) => panic!(
+                "Tree::get called with ViewId={index:?} whose node is a Container, not a View. \
+                 Callers must check `try_get` or `contains` first."
+            ),
+            None => panic!(
+                "Tree::get called with ViewId={index:?} which no longer exists in the tree. \
+                 Likely a stale id held across a close/remove."
+            ),
+        }
     }
 
     /// Try to get reference to a [View] by index. Returns `None` if node content is not a [`Content::View`].


### PR DESCRIPTION
## Summary
- replace `tree.get` with `try_get` in the Steel FFI functions that read the focused view, so plugin calls during view teardown return `None`/an error instead of panicking
- make `Tree::get`'s panic message say *which* failure mode was hit (stale id vs. container node) for the call sites that remain
- add a `commit-changes-to-history` Steel function so async callbacks that modify the document can commit to the undo history themselves

## Motivation
These came out of a plugin that renders inline content (notebook-style cell output) and therefore calls into the editor from async job callbacks fairly often. Two crash classes showed up; both exist upstream verbatim and are reachable from any plugin, not just that one.

**1. FFI calls racing view teardown.** Several FFI functions do:

```rust
let current_focus = cx.editor.tree.focus;
let view = cx.editor.tree.get(current_focus);
```

`Tree::get` is `try_get(index).unwrap()`. If a Steel callback runs while the focused view is being closed (async callback completing after `:bq`, a hook firing mid `wclose`, an `editor->doc-id` call with a `ViewId` the plugin held across a close), the editor panics. Repro sketch: register an async callback that calls `cx->current-file` (or any of the touched functions) on a timer, then close the only window before it fires.

The functions changed to `try_get`: `handle_keymap_event_impl`, `current_path`, `set_scratch_buffer_name`, `set_buffer_uri`, `cx_get_document_id`, `add_inlay_hint`, `remove_inlay_hint_by_id`, `remove_inlay_hint`. Fallbacks follow each function's existing shape: `Option`-returning functions return `None`, `set_buffer_uri` reports a proper error, void functions no-op. `add_inlay_hint`/`remove_inlay_hint*` previously guarded with `contains` + `get`, which is two lookups for the same question — `try_get` collapses that.

**2. Async document edits vs. undo history.** `EditorView::handle_event` commits pending changes to the undo history on the next key event outside insert mode. If an async plugin callback applies a transaction in between, those changes sit uncommitted until the user presses a key, and the deferred commit can observe selection state that no longer matches the changeset it is committing — which panics in selection tracking. Repro sketch: async callback applies a `Transaction` that shrinks the document while the selection sits near the end, then move the cursor.

`commit-changes-to-history` exposes `Document::append_changes_to_history` so a callback can commit its own edits at the point where they are still consistent, mirroring what the paste/key paths in `EditorView` already do.

## Design notes
- `Tree::get` keeps its panicking contract (plenty of internal callers rely on it); the change there is purely better panic messages, distinguishing "node is gone" from "node is a container", since a bare `unwrap() on a None value` from this line has very little to go on.
- `editor->doc-id` now returns `#f` instead of panicking when the `ViewId` is stale. Scheme code that blindly passes the result onward will now get a Steel-level error instead of a Rust abort, which is the better failure mode, but it is technically an observable change.
- `commit-changes-to-history` is registered in `helix/static.scm` next to the other document-editing functions.

## Possible pushback
- Whether `handle_keymap_event_impl` returning `None` (falling through to default keymap handling) is the right behavior with no focused view — I believe it is, since there is no buffer-local extension to consult, but it does change the path from "panic" to "default keymap".
- One could argue plugins should never be able to run with a stale focus and the fix belongs in the dispatch layer instead. That would be a much bigger change; these call sites are cheap to defend and the panic message improvement covers whatever remains.
- `commit-changes-to-history` trusts the plugin to call it at a sensible time. Calling it spuriously just creates empty-diff history checkpoints; it cannot corrupt state.
- `commit-changes-to-history` itself uses the `current!` macro, which panics when no view is focused — consistent with its neighbors (`insert_string` etc.), but at odds with this PR's defensive theme if you squint. Converting every `current!` user is a much bigger sweep; happy to fold this one into the `try_get` pattern here if you'd prefer it lead by example.

## Test
- cargo check -p helix-term --features steel
- cargo check --workspace
- cargo test -p helix-view --lib (58 passed)
- cargo test -p helix-term --lib --features steel (13 passed)
- cargo fmt --check is clean for the changed code (the one pre-existing deviation at the `editor-document-reload` closure is left untouched)
- manually exercised in a downstream fork for ~2 months: the try_get sweep and commit-changes-to-history both originated as fixes for crashes hit in normal plugin use

🤖 Generated with [Claude Code](https://claude.com/claude-code)
