### PR TITLE
Fix required-root-patterns loss on serialization round-trips, plus three small fixes

### DIFF
--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -95,6 +95,9 @@ impl Display for Grapheme<'_> {
 
 #[must_use]
 pub fn grapheme_width(g: &str) -> usize {
+    if g.is_empty() {
+        return 0;
+    }
     if g.as_bytes()[0] <= 127 {
         // Fast-path ascii.
         // Point 1: theoretically, ascii control characters should have zero

--- a/helix-core/src/syntax/config.rs
+++ b/helix-core/src/syntax/config.rs
@@ -126,6 +126,10 @@ impl GlobSet {
     pub fn is_match<P: AsRef<std::path::Path>>(&self, path: P) -> bool {
         self.inner.is_match(path)
     }
+
+    pub fn from_inner(inner: globset::GlobSet, patterns: Vec<String>) -> Self {
+        Self { inner, patterns }
+    }
 }
 
 impl Serialize for GlobSet {

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -2457,14 +2457,12 @@ impl HelixConfiguration {
 
                 if !patterns.is_empty() {
                     let mut builder = globset::GlobSetBuilder::new();
-                    for pattern in patterns {
-                        let glob = globset::Glob::new(&pattern)?;
+                    for pattern in &patterns {
+                        let glob = globset::Glob::new(pattern)?;
                         builder.add(glob);
                     }
-                    config.required_root_patterns = Some(GlobSet {
-                        inner: builder.build()?,
-                        patterns: Vec::new(),
-                    });
+                    config.required_root_patterns =
+                        Some(GlobSet::from_inner(builder.build()?, patterns));
                 }
             }
         } else {
@@ -2505,14 +2503,12 @@ impl HelixConfiguration {
 
                 if !patterns.is_empty() {
                     let mut builder = globset::GlobSetBuilder::new();
-                    for pattern in patterns {
-                        let glob = globset::Glob::new(&pattern)?;
+                    for pattern in &patterns {
+                        let glob = globset::Glob::new(pattern)?;
                         builder.add(glob);
                     }
-                    config.required_root_patterns = Some(GlobSet {
-                        inner: builder.build()?,
-                        patterns: Vec::new(),
-                    });
+                    config.required_root_patterns =
+                        Some(GlobSet::from_inner(builder.build()?, patterns));
                 }
             }
 

--- a/helix-tui/src/widgets/list.rs
+++ b/helix-tui/src/widgets/list.rs
@@ -60,7 +60,7 @@ impl<'a> ListItem<'a> {
 ///
 /// ```
 /// # use helix_tui::widgets::{Block, Borders, List, ListItem};
-/// # use helix_tui::style::{Style, Color, Modifier};
+/// # use helix_view::graphics::{Style, Color, Modifier};
 /// let items = [ListItem::new("Item 1"), ListItem::new("Item 2"), ListItem::new("Item 3")];
 /// List::new(items)
 ///     .block(Block::bordered().title("List"))

--- a/helix-view/src/extension.rs
+++ b/helix-view/src/extension.rs
@@ -54,13 +54,38 @@ mod steel_implementations {
         fn fmt(&self) -> Option<std::result::Result<String, std::fmt::Error>> {
             Some(Ok(format!("{:?}", self)))
         }
+        fn equality_hint(&self, other: &dyn steel::rvals::CustomType) -> bool {
+            if let Some(other) = as_underlying_type::<Self>(other) {
+                self == other
+            } else {
+                false
+            }
+        }
     }
     impl Custom for Color {
         fn fmt(&self) -> Option<std::result::Result<String, std::fmt::Error>> {
             Some(Ok(format!("{:?}", self)))
         }
+        fn equality_hint(&self, other: &dyn steel::rvals::CustomType) -> bool {
+            if let Some(other) = as_underlying_type::<Self>(other) {
+                self == other
+            } else {
+                false
+            }
+        }
     }
-    impl Custom for UnderlineStyle {}
+    impl Custom for UnderlineStyle {
+        fn fmt(&self) -> Option<std::result::Result<String, std::fmt::Error>> {
+            Some(Ok(format!("{:?}", self)))
+        }
+        fn equality_hint(&self, other: &dyn steel::rvals::CustomType) -> bool {
+            if let Some(other) = as_underlying_type::<Self>(other) {
+                self == other
+            } else {
+                false
+            }
+        }
+    }
 
     impl CustomReference for Event {}
     impl Custom for Rect {


### PR DESCRIPTION
## Summary

- preserve the source glob patterns when `required-root-patterns` is set from Steel, so the value survives serialization round-trips
- guard `grapheme_width` against empty strings instead of panicking
- fix a stale doctest import in the `List` widget docs
- implement `equality_hint` for `Style`, `Color` and `UnderlineStyle` so `equal?` works on them from Steel

Four independent commits — happy to split any of them out into separate PRs if you'd rather review them that way.

## Motivation

These all came out of building a fairly heavy Steel plugin (inline image rendering / notebook-style workflows) that leans hard on the plugin API surface — each one is a small correctness issue in code that already exists upstream.

### 1. `required-root-patterns` loses its patterns (the interesting one)

`GlobSet` in `helix-core` is a wrapper whose whole reason to exist is that `globset::GlobSet` is one-way: once built, you can't get the patterns back out. So the wrapper carries `patterns: Vec<String>` alongside the built matcher, and `Serialize` is implemented purely in terms of `patterns`.

Both branches of `update_language_server_config` in the Steel engine construct it like this:

```rust
config.required_root_patterns = Some(GlobSet {
    inner: builder.build()?,
    patterns: Vec::new(),
});
```

The matcher works, so the bug is invisible at match time — but the value is born unserializable. `get-language-server-config` reads the config back via `serde_json::json!(individual_config)`, so a plugin that sets `required-root-patterns` and later reads the config back sees an empty list. Anything else that ever re-serializes the language config silently drops the patterns the same way.

The fix adds a `GlobSet::from_inner(inner, patterns)` constructor and uses it at both call sites, keeping the source patterns alongside the built matcher. (I went with a constructor rather than just filling in the struct literal because it makes the "inner must correspond to patterns" invariant a bit harder to get wrong at the next call site.)

### 2. `grapheme_width` panics on `""`

`grapheme_width` indexes `g.as_bytes()[0]` unconditionally. Plugin-driven overlays/conceal can legitimately produce empty replacement strings (e.g. hiding a `$` delimiter by replacing it with `""`), and a hard panic takes down the whole editor. Returning `0` for an empty string is the obviously-correct width.

### 3. Stale doctest import

The `List` widget example still imports from `helix_tui::style`, which no longer exists — `Style`, `Color` and `Modifier` live in `helix_view::graphics`. `cargo test -p helix-tui --doc` fails to compile without this.

### 4. `equality_hint` for `Style` / `Color` / `UnderlineStyle`

`(equal? s1 s2)` on two identical `Style` (or `Color`, or `UnderlineStyle`) values returns `#f` because the `Custom` impls don't provide `equality_hint`. That makes cheap change-detection in plugins (only redraw/restyle when the computed style actually changed) impossible without comparing Debug strings. This follows the exact pattern `Rect`, `CursorKind` and `Mode` already use in the same module; all three types derive `PartialEq`. `UnderlineStyle` also picks up the same Debug-based `fmt` as `Style` and `Color`, so it displays as its variant name instead of the default mangled type path.

## Test

- `cargo check --workspace` — clean (one pre-existing `mismatched_lifetime_syntaxes` warning in `helix-term/src/commands/typed.rs`, untouched by this branch)
- `cargo test -p helix-core --lib` — 158 passed
- `cargo test -p helix-view --lib` — 58 passed
- `cargo test -p helix-term --lib` — 13 passed
- `cargo test -p helix-tui --doc` — 25 passed, including the `List` doctest fixed here (it fails to compile without fix 3)

## Notes for review

- Fix 1 changes the loop in `update_language_server_config` from `for pattern in patterns` to `for pattern in &patterns` so the vec survives to be stored — that's why the diff there is slightly larger than the two construction sites alone.
- For fix 2, an argument could be made that callers should never pass `""` and the panic is a useful canary. In practice the call sites are deep in render paths fed by plugin data, and "empty grapheme has zero width" seems like the saner contract than a crash.
- Fix 4's `equality_hint` is field-wise equality on the Rust values. For `Style` that means two styles that would *render* identically but differ in an unset field compare unequal — it's strict structural equality, same as the existing `Rect` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
