### PR TITLE
Expose a Steel overlay API for plugin-driven text concealment

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -349,6 +349,7 @@ These scopes are used for theming the editor interface:
 | `ui.virtual.inlay-hint.type`      | Style for inlay hints of kind `type` (language servers are not required to set a kind)         |
 | `ui.virtual.wrap`                 | Soft-wrap indicator (see the [`editor.soft-wrap` config][editor-section])                      |
 | `ui.virtual.jump-label`           | Style for virtual jump labels                                                                  |
+| `ui.virtual.conceal`              | Plugin-set conceal overlays that replace single graphemes on screen                            |
 | `ui.menu`                         | Code and command completion menus                                                              |
 | `ui.menu.selected`                | Selected autocomplete item                                                                     |
 | `ui.menu.scroll`                  | `fg` sets thumb color, `bg` sets track color of scrollbar                                      |

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -95,6 +95,11 @@ impl Display for Grapheme<'_> {
 
 #[must_use]
 pub fn grapheme_width(g: &str) -> usize {
+    if g.is_empty() {
+        // Empty graphemes occur as overlay replacements that hide the
+        // underlying grapheme entirely; they take up no width.
+        return 0;
+    }
     if g.as_bytes()[0] <= 127 {
         // Fast-path ascii.
         // Point 1: theoretically, ascii control characters should have zero

--- a/helix-term/src/commands/engine/steel/misc.scm
+++ b/helix-term/src/commands/engine/steel/misc.scm
@@ -320,6 +320,44 @@
 ;;
 (define remove-inlay-hint-by-id helix.remove-inlay-hint-by-id)
 
+(provide set-overlays!)
+;;@doc
+;;Set the conceal overlays for the current view, replacing any previously
+;;set overlays. Each overlay replaces the displayed grapheme at a character
+;;index with a replacement string, without modifying the underlying text.
+;;An empty replacement hides the grapheme entirely.
+;;
+;;```scheme
+;;(set-overlays! overlays)
+;;```
+;;
+;;overlays : (listof (pair? int? string?))
+;;
+;;Each replacement must be a single grapheme or the empty string. Overlays
+;;anchored past the end of the document are ignored. They are styled with
+;;the `ui.virtual.conceal` theme key.
+;;
+;;When the document is edited, overlay positions follow the changes and
+;;overlays whose grapheme is deleted are removed, but an edit that rewrites
+;;the concealed grapheme in place leaves the overlay on the new text.
+;;Refresh overlays on document change to stay in sync, e.g. to conceal
+;;`\alpha` as α:
+;;
+;;```scheme
+;;(set-overlays! (list (cons idx "α")            ; replace the backslash
+;;                     (cons (+ idx 1) "")       ; hide "alpha"
+;;                     (cons (+ idx 2) "")
+;;                     (cons (+ idx 3) "")
+;;                     (cons (+ idx 4) "")
+;;                     (cons (+ idx 5) "")))
+;;```
+(define set-overlays! helix.set-overlays!)
+
+(provide clear-overlays!)
+;;@doc
+;;Clear all conceal overlays for the current view.
+(define clear-overlays! helix.clear-overlays!)
+
 (provide fuzzy-match)
 ;;@doc
 ;; Convenience function to easily fuzzy match

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -3954,6 +3954,8 @@ fn load_misc_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "add-inlay-hint", add_inlay_hint)
         .register_fn_with_ctx(CTX, "remove-inlay-hint", remove_inlay_hint)
         .register_fn_with_ctx(CTX, "remove-inlay-hint-by-id", remove_inlay_hint_by_id)
+        .register_fn_with_ctx(CTX, "set-overlays!", set_plugin_overlays)
+        .register_fn_with_ctx(CTX, "clear-overlays!", clear_plugin_overlays)
         .register_fn("fuzzy-match", fuzzy_match);
 
     if generate_sources {
@@ -5519,6 +5521,55 @@ pub fn remove_inlay_hint(cx: &mut Context, char_index: usize, _completion: Steel
         .retain(|x| x.char_idx != char_index);
     doc.set_inlay_hints(view_id, new_inlay_hints);
     true
+}
+
+// "set-overlays!",
+fn set_plugin_overlays(cx: &mut Context, overlays: SteelVal) -> anyhow::Result<()> {
+    use helix_core::text_annotations::Overlay;
+    use helix_core::unicode::segmentation::UnicodeSegmentation;
+
+    let SteelVal::ListV(pairs) = overlays else {
+        anyhow::bail!("set-overlays! expects a list of (char-index . replacement) pairs");
+    };
+
+    let mut parsed = Vec::with_capacity(pairs.len());
+
+    for pair in pairs.iter() {
+        let SteelVal::Pair(pair) = pair else {
+            anyhow::bail!("set-overlays! expects (char-index . replacement) pairs, found: {pair}");
+        };
+
+        let SteelVal::IntV(char_idx) = pair.car() else {
+            anyhow::bail!("set-overlays!: char-index must be an integer");
+        };
+
+        let Ok(char_idx) = usize::try_from(char_idx) else {
+            anyhow::bail!("set-overlays!: char-index must be non-negative, found: {char_idx}");
+        };
+
+        let SteelVal::StringV(replacement) = pair.cdr() else {
+            anyhow::bail!("set-overlays!: replacement must be a string");
+        };
+
+        if replacement.graphemes(true).count() > 1 {
+            anyhow::bail!(
+                "set-overlays!: replacement must be a single grapheme or the empty string, found: {replacement}"
+            );
+        }
+
+        parsed.push(Overlay::new(char_idx, replacement.as_str()));
+    }
+
+    let (view, doc) = current!(cx.editor);
+    doc.set_plugin_overlays(view.id, parsed);
+
+    Ok(())
+}
+
+// "clear-overlays!",
+fn clear_plugin_overlays(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    doc.clear_plugin_overlays(view.id);
 }
 
 pub fn insert_string(cx: &mut Context, string: SteelString) {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -151,6 +151,14 @@ pub struct Document {
     pub(crate) inlay_hints: HashMap<ViewId, DocumentInlayHints>,
     /// Jump label overlays for each view.
     pub(crate) jump_labels: HashMap<ViewId, Vec<Overlay>>,
+    /// Plugin-managed conceal overlays for each view, replacing single
+    /// graphemes on screen without modifying the underlying text.
+    ///
+    /// Unlike `jump_labels`, which are transient, these persist until
+    /// explicitly cleared. Positions are mapped through document changes;
+    /// overlays whose grapheme is deleted are removed (see
+    /// [`Self::set_plugin_overlays`] for the exact contract).
+    plugin_overlays: HashMap<ViewId, Vec<Overlay>>,
     /// LSP document highlights for each view, stored as char ranges.
     pub(crate) document_highlights: HashMap<ViewId, DocumentHighlights>,
     /// Set to `true` when the document is updated, reset to `false` on the next inlay hints
@@ -761,6 +769,7 @@ impl Document {
             name: None,
             readonly: false,
             jump_labels: HashMap::new(),
+            plugin_overlays: HashMap::new(),
             document_highlights: HashMap::new(),
             color_swatches: None,
             document_links: Vec::new(),
@@ -1437,6 +1446,7 @@ impl Document {
         self.selections.remove(&view_id);
         self.inlay_hints.remove(&view_id);
         self.jump_labels.remove(&view_id);
+        self.plugin_overlays.remove(&view_id);
         self.document_highlights.remove(&view_id);
         self.document_highlight_controllers.remove(&view_id);
     }
@@ -1589,6 +1599,29 @@ impl Document {
             apply_inlay_hint_changes(other_inlay_hints);
             apply_inlay_hint_changes(padding_after_inlay_hints);
         }
+
+        // Map plugin overlay positions through the changes so each overlay
+        // stays anchored to the grapheme it conceals. Overlays whose grapheme
+        // is deleted collapse to an empty range and are removed: a conceal
+        // that drifted onto unrelated text would be worse than briefly
+        // revealing the source text.
+        for overlays in self.plugin_overlays.values_mut() {
+            let mut ends: Vec<_> = overlays
+                .iter()
+                .map(|overlay| overlay.char_idx + 1)
+                .collect();
+            changes.update_positions(
+                overlays
+                    .iter_mut()
+                    .map(|overlay| (&mut overlay.char_idx, Assoc::After)),
+            );
+            changes.update_positions(ends.iter_mut().map(|end| (end, Assoc::After)));
+            let mut ends = ends.into_iter();
+            overlays.retain(|overlay| overlay.char_idx < ends.next().unwrap());
+        }
+        // Mirror set_plugin_overlays: an emptied layer drops its map entry
+        // rather than lingering as an empty Vec.
+        self.plugin_overlays.retain(|_, overlays| !overlays.is_empty());
 
         for highlights in self.document_highlights.values_mut() {
             let text_len = self.text.len_chars();
@@ -2397,6 +2430,35 @@ impl Document {
         self.jump_labels.remove(&view_id);
     }
 
+    /// Set the plugin-managed conceal overlays for `view_id`, replacing any
+    /// previously set overlays.
+    ///
+    /// Overlays are sorted by position; overlays anchored past the end of the
+    /// document are discarded. When the document is edited, the positions of
+    /// the remaining overlays are mapped through the changes so they stay
+    /// anchored to the grapheme they conceal, and overlays whose grapheme is
+    /// deleted are removed. The mapping is purely positional: an edit that
+    /// rewrites the concealed grapheme in place leaves the overlay on the new
+    /// text, so plugins should refresh their overlays on document change.
+    pub fn set_plugin_overlays(&mut self, view_id: ViewId, mut overlays: Vec<Overlay>) {
+        let text_len = self.text.len_chars();
+        overlays.retain(|overlay| overlay.char_idx < text_len);
+        overlays.sort_by_key(|overlay| overlay.char_idx);
+        if overlays.is_empty() {
+            self.plugin_overlays.remove(&view_id);
+        } else {
+            self.plugin_overlays.insert(view_id, overlays);
+        }
+    }
+
+    pub fn clear_plugin_overlays(&mut self, view_id: ViewId) {
+        self.plugin_overlays.remove(&view_id);
+    }
+
+    pub fn plugin_overlays(&self, view_id: ViewId) -> Option<&[Overlay]> {
+        self.plugin_overlays.get(&view_id).map(Vec::as_slice)
+    }
+
     pub fn set_document_highlights(
         &mut self,
         view_id: ViewId,
@@ -2526,6 +2588,57 @@ mod test {
                 range_length: None,
             }]
         );
+    }
+
+    #[test]
+    fn plugin_overlays_remap_through_edits() {
+        let text = Rope::from("hello \\alpha world");
+        let mut doc = Document::from(
+            text,
+            None,
+            Arc::new(ArcSwap::new(Arc::new(Config::default()))),
+            Arc::new(ArcSwap::from_pointee(syntax::Loader::default())),
+        );
+        let view = ViewId::default();
+        doc.set_selection(view, Selection::single(0, 0));
+
+        // Conceal "\alpha" (chars 6..=11): replace the backslash with α and
+        // hide the rest. Passed unsorted and with an out-of-bounds entry to
+        // exercise the invariants enforced on set.
+        doc.set_plugin_overlays(
+            view,
+            vec![
+                Overlay::new(7, ""),
+                Overlay::new(6, "α"),
+                Overlay::new(8, ""),
+                Overlay::new(9, ""),
+                Overlay::new(10, ""),
+                Overlay::new(11, ""),
+                Overlay::new(999, "x"),
+            ],
+        );
+
+        let positions = |doc: &Document| -> Vec<usize> {
+            doc.plugin_overlays(view)
+                .unwrap()
+                .iter()
+                .map(|overlay| overlay.char_idx)
+                .collect()
+        };
+        assert_eq!(positions(&doc), [6, 7, 8, 9, 10, 11]);
+
+        // Inserting before the concealed range shifts the overlays right.
+        let transaction = Transaction::change(doc.text(), [(0, 0, Some(">> ".into()))].into_iter());
+        doc.apply(&transaction, view);
+        assert_eq!(doc.text(), ">> hello \\alpha world");
+        assert_eq!(positions(&doc), [9, 10, 11, 12, 13, 14]);
+
+        // Deleting concealed graphemes ("ph") drops their overlays and
+        // shifts the rest, instead of letting them drift onto other text.
+        let transaction = Transaction::change(doc.text(), [(12, 14, None)].into_iter());
+        doc.apply(&transaction, view);
+        assert_eq!(doc.text(), ">> hello \\ala world");
+        assert_eq!(positions(&doc), [9, 10, 11, 12]);
     }
 
     #[test]

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -447,6 +447,13 @@ impl View {
     ) -> TextAnnotations<'a> {
         let mut text_annotations = TextAnnotations::default();
 
+        // Plugin conceal overlays are added before jump labels so that jump
+        // labels win when both target the same grapheme.
+        if let Some(overlays) = doc.plugin_overlays(self.id) {
+            let style = theme.and_then(|t| t.find_highlight("ui.virtual.conceal"));
+            text_annotations.add_overlay(overlays, style);
+        }
+
         if let Some(labels) = doc.jump_labels.get(&self.id) {
             let style = theme.and_then(|t| t.find_highlight("ui.virtual.jump-label"));
             text_annotations.add_overlay(labels, style);

--- a/runtime/themes/naysayer.toml
+++ b/runtime/themes/naysayer.toml
@@ -13,6 +13,7 @@
 "ui.statusline.inactive" = { fg = "text", bg = "bg" }
 "ui.virtual" = "indent"
 "ui.virtual.ruler" = { bg = "line-fg" }
+"ui.virtual.conceal" = { fg = "white", modifiers = ["bold"] }
 "ui.cursor.match" = { bg = "cyan" }
 "ui.cursor" = { bg = "#777777" }
 "ui.cursor.primary" = { bg = "white" }

--- a/theme.toml
+++ b/theme.toml
@@ -60,6 +60,7 @@ tabstop = { modifiers = ["italic"], bg = "bossanova" }
 "ui.virtual" = { fg = "comet" }
 "ui.virtual.ruler" = { bg = "bossanova" }
 "ui.virtual.jump-label" = { fg = "apricot", modifiers = ["bold"] }
+"ui.virtual.conceal" = { fg = "white", modifiers = ["bold"] }
 
 "ui.virtual.indent-guide" = { fg = "comet" }
 


### PR DESCRIPTION
## Summary
- add per-view, plugin-managed conceal overlays to `Document`, each replacing a single grapheme on screen without modifying the buffer
- expose them to Steel as `set-overlays!` / `clear-overlays!` on `helix/misc.scm`
- style them with a new `ui.virtual.conceal` theme key (added to `theme.toml`, `naysayer.toml`, and the themes book page)
- remap overlay positions through the `ChangeSet` on every edit so they stay anchored, dropping overlays whose grapheme is deleted
- fix a panic in `grapheme_width` on empty strings, which are valid overlay replacements used to hide a grapheme

## Motivation
Inlay hints have insert semantics: they add virtual text next to the buffer text. Plugins also need replace semantics — showing a different grapheme *instead of* the one in the buffer, ligature-style.

The driving use case is a Typst/LaTeX concealer plugin: rendering `\alpha` as `α` while editing, without touching the file. The plugin replaces the backslash with `α` and hides the remaining graphemes with empty-string overlays:

```scheme
(set-overlays! (list (cons idx "α")      ; replace the backslash
                     (cons (+ idx 1) "") ; hide "alpha"
                     (cons (+ idx 2) "")
                     (cons (+ idx 3) "")
                     (cons (+ idx 4) "")
                     (cons (+ idx 5) "")))
```

The renderer already has exactly the right primitive — `TextAnnotations::add_overlay`, used by jump labels — but nothing persistent or plugin-settable feeds it. This PR adds that storage and the Steel surface for it, and nothing else: no new rendering machinery.

## Design notes
**Staleness contract.** Overlays anchor to char positions, so document edits would silently misplace them. This PR handles edits in `Document::apply` the same way inlay hints and document highlights already do: positions are mapped through the `ChangeSet` with `Assoc::After`. Each overlay is treated as the range `char_idx..char_idx + 1`; if the edit collapses that range (the concealed grapheme was deleted), the overlay is dropped rather than left to drift onto unrelated text. The mapping is positional, not content-aware: an edit that rewrites the concealed grapheme in place (e.g. `r` over the backslash) leaves the overlay on the new text until the plugin refreshes. That trade-off matches the in-tree precedents (inlay hints can be stale too, hence `inlay_hints_oudated`), and the concealer plugin re-runs on document change anyway — the contract is stated in the rustdoc on `Document::set_plugin_overlays` and in the Steel docstring. There is a unit test covering shift-on-insert and drop-on-delete (`plugin_overlays_remap_through_edits`).

**Encapsulation.** The storage is a private field on `Document` behind `set_plugin_overlays` / `clear_plugin_overlays` / `plugin_overlays`, mirroring the `document_highlights` accessors. The setter enforces the invariants the renderer and the remap rely on: overlays sorted by position (`add_overlay` requires this), out-of-bounds anchors discarded (`update_positions` panics on positions past the changeset).

**Input validation.** `set-overlays!` raises a Steel error on malformed input — non-pair entries, negative indices, multi-grapheme replacements (invalid per the `Overlay` doc) — instead of skipping silently, so plugin bugs surface early.

**Render layering.** The conceal layer is added before jump labels in `View::text_annotations`, so jump labels win when both target the same grapheme.

**`grapheme_width("")`.** Hiding a grapheme means an empty replacement, and `grapheme_width` indexed `as_bytes()[0]` unchecked. It now returns 0 for empty strings; split out as its own commit since it is a panic fix independent of the rest.

## Test
- `cargo check --workspace`
- `cargo test -p helix-view --lib` (59 passed, includes the new remap test), `cargo test -p helix-core --lib` (158 passed), `cargo test -p helix-term --lib` (13 passed)
- `cargo fmt --check` is clean for everything this PR touches (the one remaining diff, `steel/mod.rs:1480`, predates this branch)
- a predecessor of this API (same storage and Steel surface, without the edit-time remap) has been the backend of a Typst/LaTeX concealer plugin ([nothelix](https://github.com/koalazub/nothelix), `plugin/nothelix/conceal.scm`) for two months: conceals applied on open/change/focus hooks, edits inside and around concealed regions, undo/redo. The remap on edit is new in this PR and is covered by the unit test

## Things reviewers may want to weigh in on
- the positional (not content-aware) remap described above; a content check (compare the grapheme under the overlay before/after) would close the rewrite-in-place gap at the cost of diverging from how inlay hints and highlights behave
- `set-overlays!` replaces the whole overlay set for the view per call rather than offering incremental add/remove; for a concealer that recomputes per change this is the simpler contract, and it keeps the FFI surface to two functions
- the default `ui.virtual.conceal` style is bold white rather than inheriting the dimmed `ui.virtual`: concealed graphemes stand in for real text, so rendering them like virtual text reads as wrong emphasis — but the exact default is bikesheddable
- overlays are per-view (keyed by `ViewId`, like jump labels and inlay hints); a plugin that wants document-wide conceals sets them for the focused view, which is what the hook-driven flow naturally does

> Note: the first commit (`grapheme_width("")` fix) is also submitted standalone in my small-fixes batch PR — whichever lands first, I'll rebase the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
