### PR TITLE
fix typo in extension keymap macro definition

### DIFF
--- a/helix-term/src/commands/engine/steel/keymaps.scm
+++ b/helix-term/src/commands/engine/steel/keymaps.scm
@@ -213,7 +213,7 @@
     [(_ (extension name (inherit-from kmap)) (with-map bindings))
      (helix.keymaps.#%add-extension-or-labeled-keymap name (merge-keybindings kmap bindings))]
 
-    [(_ (extension name (inherit-from map)) args ...)
+    [(_ (extension name (inherit-from kmap)) args ...)
      (helix.keymaps.#%add-extension-or-labeled-keymap name
                                                       (merge-keybindings kmap (keymap args ...)))]
 


### PR DESCRIPTION
This fixes the typo that currently prevents the `(keymap (extension "foo" (inherit-from bar)) ...)` syntax from working.