### PR TITLE
do not generate builtin sources on every startup/reload

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -4155,7 +4155,7 @@ fn configure_engine_impl(mut engine: Engine) -> Engine {
         SteelVal::IntV(engine.engine_id().as_usize() as _),
     );
 
-    configure_builtin_sources(&mut engine, true);
+    configure_builtin_sources(&mut engine, false);
 
     // Hooks
     engine.register_fn("register-hook!", register_hook);


### PR DESCRIPTION
When investigating #122 my changes in `keymaps.scm` would get reverted on every config reload.

The other modules in `~/.local/share/steel/cogs/helix` would also get overwritten with their old versions on every start or config reload.

These modules are already installed by `cargo xtask steel` too.

This seems like unintended behavior. If it is intended, it should be documented.

With the above fixed, the changes in `~/.local/share/steel/cogs/helix` would still not apply, as helix would still use the version of the module it was compiled with.

Not sure if this is intended behavior. If it is intended, it should be documented.
