### PR TITLE
steel: add custom Steel mode API

### DIFF
--- a/helix-term/src/commands/engine/steel/misc.scm
+++ b/helix-term/src/commands/engine/steel/misc.scm
@@ -332,3 +332,33 @@
 ;; pattern : string?
 ;; input-list : (list? string?)
 (define fuzzy-match helix.fuzzy-match)
+
+(provide steel-mode)
+;;@doc
+;;Returns the active Steel mode name, or #false if no Steel mode is active.
+(define steel-mode helix.steel-mode)
+
+(provide set-steel-mode!)
+;;@doc
+;;Set the active Steel mode by name. The name is shown in the statusline.
+;;Use register-steel-mode-keymap! to bind keys for the mode.
+(define set-steel-mode! helix.set-steel-mode!)
+
+(provide unset-steel-mode!)
+;;@doc
+;;Clear the active Steel mode.
+(define unset-steel-mode! helix.unset-steel-mode!)
+
+(provide register-steel-mode-keymap!)
+;;@doc
+;;Register a keymap for a named Steel mode. The keymap takes priority over
+;;the default helix keybindings when that mode is active.
+;;
+;;```scheme
+;;(register-steel-mode-keymap! name keymap)
+;;```
+;;
+;;name : string?
+;;keymap : keymap?
+(define (register-steel-mode-keymap! name keymap)
+  (helix.register-steel-mode-keymap! name (value->jsexpr-string keymap)))

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -427,6 +427,36 @@ fn reset_buffer_extension_keymap() {
     guard.reverse.clear();
 }
 
+/// Per-name keymaps for Steel-defined modes. When a steel mode is active,
+/// `handle_keymap_event_impl` checks this map first; unrecognised keys fall
+/// through to the buffer/extension keymap.
+pub static STEEL_MODE_KEYBINDING_MAP: Lazy<Mutex<HashMap<String, EmbeddedKeyMap>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+fn set_custom_mode(cx: &mut Context, name: SteelString) {
+    cx.editor.steel_mode = Some(name.to_string());
+}
+
+fn unset_custom_mode(cx: &mut Context) {
+    cx.editor.steel_mode = None;
+}
+
+fn get_custom_mode(cx: &mut Context) -> SteelVal {
+    match cx.editor.steel_mode.as_deref() {
+        Some(s) => SteelVal::StringV(s.into()),
+        None => SteelVal::BoolV(false),
+    }
+}
+
+fn register_steel_mode_keymap(name: SteelString, keymap: String) -> anyhow::Result<()> {
+    let embedded = string_to_embedded_keymap(keymap)?;
+    STEEL_MODE_KEYBINDING_MAP
+        .lock()
+        .unwrap()
+        .insert(name.to_string(), embedded);
+    Ok(())
+}
+
 enum LspKind {
     Call(RootedSteelVal),
     Notification(RootedSteelVal),
@@ -1966,6 +1996,22 @@ impl SteelScriptingEngine {
         cx: &mut Context,
         event: KeyEvent,
     ) -> Option<KeymapResult> {
+        // Steel mode keymaps act as priority overrides: if the active steel mode
+        // has registered a keymap that contains this (mode, key) pair, use it.
+        // Unrecognised keys fall through to the buffer/extension keymap below.
+        if let Some(ref mode_name) = cx.editor.steel_mode.clone() {
+            let km_guard = STEEL_MODE_KEYBINDING_MAP.lock().unwrap();
+            if let Some(keymap) = km_guard.get(mode_name) {
+                if keymap.0.contains_key(&mode) {
+                    let result = editor.keymaps.get_with_map(&keymap.0, mode, event);
+                    drop(km_guard);
+                    if !matches!(result, KeymapResult::NotFound) {
+                        return Some(result);
+                    }
+                }
+            }
+        }
+
         let extension = {
             let current_focus = cx.editor.tree.focus;
             let view = cx.editor.tree.get(current_focus);
@@ -4015,7 +4061,11 @@ fn load_misc_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "add-inlay-hint", add_inlay_hint)
         .register_fn_with_ctx(CTX, "remove-inlay-hint", remove_inlay_hint)
         .register_fn_with_ctx(CTX, "remove-inlay-hint-by-id", remove_inlay_hint_by_id)
-        .register_fn("fuzzy-match", fuzzy_match);
+        .register_fn("fuzzy-match", fuzzy_match)
+        .register_fn_with_ctx(CTX, "steel-mode", get_custom_mode)
+        .register_fn_with_ctx(CTX, "set-steel-mode!", set_custom_mode)
+        .register_fn_with_ctx(CTX, "unset-steel-mode!", unset_custom_mode)
+        .register_fn("register-steel-mode-keymap!", register_steel_mode_keymap);
 
     if generate_sources {
         generate_module("misc.scm", &builtin_misc_module);

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -195,6 +195,19 @@ where
 {
     let visible = context.focused;
     let config = context.editor.config();
+
+    if visible {
+        if let Some(name) = context.editor.steel_mode.clone() {
+            let style = if config.color_modes {
+                context.editor.theme.get("ui.statusline.select")
+            } else {
+                Style::default()
+            };
+            write(context, Span::styled(format!(" {} ", name), style));
+            return;
+        }
+    }
+
     let modenames = &config.statusline.mode;
     let mode_str = match context.editor.mode() {
         Mode::Insert => &modenames.insert,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1366,6 +1366,10 @@ pub struct Editor {
     pub editor_clipping: ClippingConfiguration,
 
     pub workspace_trust: WorkspaceTrust,
+
+    /// Active Steel-defined mode name, shown in the statusline instead of the
+    /// normal mode label. `None` means no Steel mode is active.
+    pub steel_mode: Option<String>,
 }
 
 #[derive(Default)]
@@ -1501,6 +1505,7 @@ impl Editor {
             editor_clipping: ClippingConfiguration::default(),
             dir_stack: VecDeque::with_capacity(DIR_STACK_CAP),
             workspace_trust,
+            steel_mode: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a small API for defining named Steel modes with per-mode keymaps that override the default helix bindings when active. The mode name is shown in the statusline in place of the normal mode label.

**Rust side** (`mod.rs`, `editor.rs`, `statusline.rs`):
- `Editor::steel_mode: Option<String>` — tracks the active steel mode name
- `STEEL_MODE_KEYBINDING_MAP` — global registry mapping mode names to keymaps
- `set-steel-mode!` / `unset-steel-mode!` / `steel-mode` — context functions
- `register-steel-mode-keymap!` — registers a JSON keymap for a named mode
- `handle_keymap_event_impl` — checks the active steel mode keymap first; unrecognised keys fall through to the buffer/extension keymap as normal
- statusline — renders the steel mode name styled as `ui.statusline.select` when a steel mode is active

**Scheme side** (`misc.scm`):
- Exports and documents all four new functions with `;;@doc` comments

## Example

```scheme
(register-steel-mode-keymap! "visual-line"
  (hash "normal" (hash "j" 'extend_line_below
                        "k" 'extend_line_above
                        "V"  'extend_line_below
                        "Escape" ':unset-steel-mode!)))

(define (enter-visual-line-mode)
  (set-steel-mode! "visual-line"))
```

## Test plan

- [ ] `set-steel-mode!` / `unset-steel-mode!` toggle the active mode
- [ ] `steel-mode` returns the current mode name or `#false`
- [ ] Registered keymap keys fire correctly when the mode is active
- [ ] Unregistered keys fall through to normal helix bindings
- [ ] Statusline shows the steel mode name (styled as select) when active
- [ ] Statusline reverts to normal mode label when mode is unset

🤖 Generated with [Claude Code](https://claude.ai/claude-code)