### PR TITLE
steel: expose LSP WorkDoneProgress as a Steel hook

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -922,6 +922,11 @@ impl Application {
                             token,
                             value: lsp::ProgressParamsValue::WorkDone(work),
                         } = params;
+                        let token_str = match &token {
+                            lsp::NumberOrString::Number(n) => n.to_string(),
+                            lsp::NumberOrString::String(s) => s.clone(),
+                        };
+                        let server_name = language_server!().name().to_string();
                         let (title, message, percentage) = match &work {
                             lsp::WorkDoneProgress::Begin(lsp::WorkDoneProgressBegin {
                                 title,
@@ -944,8 +949,8 @@ impl Application {
                                     }
                                     self.editor.clear_status();
                                     helix_event::dispatch(helix_view::events::LspProgressUpdate {
-                                        server_id,
-                                        token: token.to_string(),
+                                        server_name: server_name.clone(),
+                                        token: token_str.clone(),
                                         kind: "end".to_string(),
                                         title: None,
                                         message: None,
@@ -988,8 +993,8 @@ impl Application {
                                 self.lsp_progress
                                     .begin(server_id, token.clone(), begin_status);
                                 helix_event::dispatch(helix_view::events::LspProgressUpdate {
-                                    server_id,
-                                    token: token.to_string(),
+                                    server_name: server_name.clone(),
+                                    token: token_str.clone(),
                                     kind: "begin".to_string(),
                                     title: fire_title,
                                     message: fire_message,
@@ -1002,8 +1007,8 @@ impl Application {
                                 self.lsp_progress
                                     .update(server_id, token.clone(), report_status);
                                 helix_event::dispatch(helix_view::events::LspProgressUpdate {
-                                    server_id,
-                                    token: token.to_string(),
+                                    server_name: server_name.clone(),
+                                    token: token_str.clone(),
                                     kind: "report".to_string(),
                                     title: None,
                                     message: fire_message,
@@ -1017,8 +1022,8 @@ impl Application {
                                     editor_view.spinners_mut().get_or_create(server_id).stop();
                                 };
                                 helix_event::dispatch(helix_view::events::LspProgressUpdate {
-                                    server_id,
-                                    token: token.to_string(),
+                                    server_name: server_name.clone(),
+                                    token: token_str.clone(),
                                     kind: "end".to_string(),
                                     title: None,
                                     message: fire_message,

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -943,6 +943,14 @@ impl Application {
                                         editor_view.spinners_mut().get_or_create(server_id).stop();
                                     }
                                     self.editor.clear_status();
+                                    helix_event::dispatch(helix_view::events::LspProgressUpdate {
+                                        server_id,
+                                        token: token.to_string(),
+                                        kind: "end".to_string(),
+                                        title: None,
+                                        message: None,
+                                        percentage: None,
+                                    });
 
                                     // we want to render to clear any leftover spinners or messages
                                     return;
@@ -974,18 +982,48 @@ impl Application {
 
                         match work {
                             lsp::WorkDoneProgress::Begin(begin_status) => {
+                                let fire_title = Some(begin_status.title.clone());
+                                let fire_message = begin_status.message.clone();
+                                let fire_percentage = begin_status.percentage;
                                 self.lsp_progress
                                     .begin(server_id, token.clone(), begin_status);
+                                helix_event::dispatch(helix_view::events::LspProgressUpdate {
+                                    server_id,
+                                    token: token.to_string(),
+                                    kind: "begin".to_string(),
+                                    title: fire_title,
+                                    message: fire_message,
+                                    percentage: fire_percentage,
+                                });
                             }
                             lsp::WorkDoneProgress::Report(report_status) => {
+                                let fire_message = report_status.message.clone();
+                                let fire_percentage = report_status.percentage;
                                 self.lsp_progress
                                     .update(server_id, token.clone(), report_status);
+                                helix_event::dispatch(helix_view::events::LspProgressUpdate {
+                                    server_id,
+                                    token: token.to_string(),
+                                    kind: "report".to_string(),
+                                    title: None,
+                                    message: fire_message,
+                                    percentage: fire_percentage,
+                                });
                             }
-                            lsp::WorkDoneProgress::End(_) => {
+                            lsp::WorkDoneProgress::End(end_status) => {
+                                let fire_message = end_status.message.clone();
                                 self.lsp_progress.end_progress(server_id, &token);
                                 if !self.lsp_progress.is_progressing(server_id) {
                                     editor_view.spinners_mut().get_or_create(server_id).stop();
                                 };
+                                helix_event::dispatch(helix_view::events::LspProgressUpdate {
+                                    server_id,
+                                    token: token.to_string(),
+                                    kind: "end".to_string(),
+                                    title: None,
+                                    message: fire_message,
+                                    percentage: None,
+                                });
                             }
                         }
                     }

--- a/helix-term/src/commands/engine/steel/misc.scm
+++ b/helix-term/src/commands/engine/steel/misc.scm
@@ -336,7 +336,7 @@
 ;;@doc
 ;; Register a hook that fires on every LSP WorkDoneProgress begin/report/end notification.
 ;; The callback receives six arguments:
-;;   server-id  : integer — the language server ID
+;;   server-name : string  — the language server name
 ;;   token      : string  — the progress token (number or string from the server)
 ;;   kind       : string  — "begin" | "report" | "end"
 ;;   title      : string? — task title (only present on "begin")

--- a/helix-term/src/commands/engine/steel/misc.scm
+++ b/helix-term/src/commands/engine/steel/misc.scm
@@ -332,3 +332,21 @@
 ;; pattern : string?
 ;; input-list : (list? string?)
 (define fuzzy-match helix.fuzzy-match)
+
+;;@doc
+;; Register a hook that fires on every LSP WorkDoneProgress begin/report/end notification.
+;; The callback receives six arguments:
+;;   server-id  : integer — the language server ID
+;;   token      : string  — the progress token (number or string from the server)
+;;   kind       : string  — "begin" | "report" | "end"
+;;   title      : string? — task title (only present on "begin")
+;;   message    : string? — optional human-readable message
+;;   percentage : integer? — optional 0-100 completion percentage
+;;
+;; Example:
+;; ```scheme
+;; (register-hook! 'lsp-progress
+;;   (lambda (server-id token kind title message percentage)
+;;     (when (equal? kind "begin")
+;;       (display (string-append "LSP: " (or title token) "\n")))))
+;; ```

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -3566,7 +3566,7 @@ fn register_lsp_progress(
     register_hook!(move |event: &mut LspProgressUpdate| {
         let cloned_func = rooted.value().clone();
         let args = [
-            event.server_id.into_steelval().unwrap(),
+            event.server_name.clone().into_steelval().unwrap(),
             event.token.clone().into_steelval().unwrap(),
             event.kind.clone().into_steelval().unwrap(),
             event.title.clone().into_steelval().unwrap(),

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -33,7 +33,7 @@ use helix_view::{
     },
     events::{
         DocumentDidChange, DocumentDidClose, DocumentDidOpen, DocumentFocusLost, DocumentSaved,
-        SelectionDidChange,
+        LspProgressUpdate, SelectionDidChange,
     },
     extension::{document_id_to_usize, steel_implementations::CustomStatusElement},
     graphics::CursorKind,
@@ -3388,6 +3388,7 @@ fn register_hook(event_kind: String, callback_fn: SteelVal) -> steel::UnRecovera
         "document-saved" => register_document_saved(generation, rooted),
         "document-changed" => register_document_changed(generation, rooted),
         "document-closed" => register_document_closed(generation, rooted),
+        "lsp-progress" => register_lsp_progress(generation, rooted),
         _ => steelerr!(Generic => "Unable to register hook: Unknown event type: {}", event_kind)
             .into(),
     }
@@ -3553,6 +3554,27 @@ fn register_document_focus_lost(
             construct_callback(generation, cloned_func, [doc_id.into_steelval().unwrap()]);
         job::dispatch_blocking_jobs(callback);
 
+        Ok(())
+    });
+    Ok(SteelVal::Void).into()
+}
+
+fn register_lsp_progress(
+    generation: usize,
+    rooted: RootedSteelVal,
+) -> steel::UnRecoverableResult {
+    register_hook!(move |event: &mut LspProgressUpdate| {
+        let cloned_func = rooted.value().clone();
+        let args = [
+            event.server_id.into_steelval().unwrap(),
+            event.token.clone().into_steelval().unwrap(),
+            event.kind.clone().into_steelval().unwrap(),
+            event.title.clone().into_steelval().unwrap(),
+            event.message.clone().into_steelval().unwrap(),
+            event.percentage.into_steelval().unwrap(),
+        ];
+        let callback = construct_callback(generation, cloned_func, args);
+        job::dispatch_blocking_jobs(callback);
         Ok(())
     });
     Ok(SteelVal::Void).into()

--- a/helix-term/src/events.rs
+++ b/helix-term/src/events.rs
@@ -3,7 +3,7 @@ use helix_view::document::Mode;
 use helix_view::events::{
     ConfigDidChange, DiagnosticsDidChange, DocumentDidChange, DocumentDidClose, DocumentDidOpen,
     DocumentFocusLost, DocumentSaved, LanguageServerExited, LanguageServerInitialized,
-    SelectionDidChange,
+    LspProgressUpdate, SelectionDidChange,
 };
 
 use crate::commands;
@@ -32,5 +32,6 @@ pub fn register() {
     register_event::<DiagnosticsDidChange>();
     register_event::<LanguageServerInitialized>();
     register_event::<LanguageServerExited>();
+    register_event::<LspProgressUpdate>();
     register_event::<ConfigDidChange>();
 }

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -41,7 +41,7 @@ events! {
         kind: String,
         title: Option<String>,
         message: Option<String>,
-        percentage: Option<u32>,
+        percentage: Option<u32>
     }
 
     // NOTE: this event is simple for now and is expected to change as the config system evolves.

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -36,7 +36,7 @@ events! {
     }
 
     LspProgressUpdate {
-        server_id: LanguageServerId,
+        server_name: String,
         token: String,
         kind: String,
         title: Option<String>,

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -35,6 +35,18 @@ events! {
         server_id: LanguageServerId
     }
 
+    /// Fired for every WorkDoneProgress begin/report/end notification.
+    /// Uses owned data so it can be dispatched without holding an Editor borrow.
+    LspProgressUpdate {
+        server_id: LanguageServerId,
+        token: String,
+        /// "begin" | "report" | "end"
+        kind: String,
+        title: Option<String>,
+        message: Option<String>,
+        percentage: Option<u32>,
+    }
+
     // NOTE: this event is simple for now and is expected to change as the config system evolves.
     // Ideally it would say what changed.
     ConfigDidChange<'a> {

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -38,7 +38,6 @@ events! {
     LspProgressUpdate {
         server_id: LanguageServerId,
         token: String,
-        /// "begin" | "report" | "end"
         kind: String,
         title: Option<String>,
         message: Option<String>,

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -35,8 +35,6 @@ events! {
         server_id: LanguageServerId
     }
 
-    /// Fired for every WorkDoneProgress begin/report/end notification.
-    /// Uses owned data so it can be dispatched without holding an Editor borrow.
     LspProgressUpdate {
         server_id: LanguageServerId,
         token: String,


### PR DESCRIPTION
## Summary

Adds an `lsp-progress` hook so Steel scripts can receive real-time LSP WorkDoneProgress notifications. This is the Rust foundation needed to build [fidget.nvim](https://github.com/j-hui/fidget.nvim)-style LSP progress overlay UIs entirely in Steel.

**New event** (`helix-view/src/events.rs`):
- `LspProgressUpdate` — fully-owned struct (no lifetimes) with `server_id`, `token`, `kind` (`"begin"` | `"report"` | `"end"`), `title`, `message`, `percentage`. Owned data avoids borrow conflicts with `Application.lsp_progress`.

**Dispatch** (`helix-term/src/application.rs`):
- Fires after every `WorkDoneProgress` arm in `handle_language_server_message`, including the early-return End-with-no-message branch.

**Hook wiring** (`helix-term/src/commands/engine/steel/mod.rs`):
- `register_lsp_progress` follows the `dispatch_blocking_jobs` pattern (same as `document-saved`, `document-changed`, etc.)
- Callback receives: `server-id token kind title message percentage`

**Documentation** (`misc.scm`): `;;@doc` comment with argument types and example.

## Usage

```scheme
(register-hook! 'lsp-progress
  (lambda (server-id token kind title message percentage)
    (cond
      [(equal? kind "begin")
       (display (string-append "LSP started: " (or title token) "\n"))]
      [(equal? kind "report")
       (when percentage
         (display (string-append (number->string percentage) "%\n")))]
      [(equal? kind "end")
       (display "LSP done\n")])))
```

## Test plan

- [ ] Hook fires on LSP begin/report/end notifications
- [ ] `kind` is `"begin"` / `"report"` / `"end"` correctly
- [ ] `title` is present on begin, `#false` on report/end
- [ ] `percentage` is an integer or `#false`
- [ ] End-with-no-message branch (early return) still fires the hook
- [ ] Existing statusline spinner and `lsp_progress` map behaviour unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)