### PR TITLE
steel: add custom modes, LSP progress hook, and script-defined document highlights

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chardetng"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,7 +723,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -771,6 +777,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -866,6 +878,17 @@ dependencies = [
  "rkyv",
  "serde",
  "simdutf8",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1053,7 +1076,7 @@ dependencies = [
  "gix-worktree-stream",
  "nonempty",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1080,7 +1103,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-bom",
 ]
 
@@ -1143,7 +1166,7 @@ dependencies = [
  "gix-ref",
  "gix-sec",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-bom",
 ]
 
@@ -1157,7 +1180,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1193,7 +1216,7 @@ dependencies = [
  "gix-trace",
  "gix-traverse",
  "gix-worktree",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1213,7 +1236,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "gix-worktree",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1228,7 +1251,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1256,7 +1279,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prodash",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "zlib-rs",
 ]
@@ -1279,7 +1302,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1293,7 +1316,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "gix-utils",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1317,7 +1340,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1379,7 +1402,7 @@ dependencies = [
  "memmap2",
  "rustix 1.1.4",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1390,7 +1413,7 @@ checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1409,7 +1432,7 @@ dependencies = [
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1430,7 +1453,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1449,7 +1472,7 @@ dependencies = [
  "gix-path",
  "memmap2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "uluru",
 ]
 
@@ -1462,7 +1485,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1474,7 +1497,7 @@ dependencies = [
  "bstr",
  "gix-trace",
  "gix-validate",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1489,7 +1512,7 @@ dependencies = [
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1508,7 +1531,7 @@ dependencies = [
  "gix-utils",
  "maybe-async",
  "nonempty",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1539,7 +1562,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "memmap2",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1555,7 +1578,7 @@ dependencies = [
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1587,7 +1610,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1612,7 +1635,7 @@ dependencies = [
  "gix-hash",
  "gix-lock",
  "nonempty",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1635,7 +1658,7 @@ dependencies = [
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1650,7 +1673,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1685,7 +1708,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1702,7 +1725,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1714,7 +1737,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "percent-encoding",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1962,7 +1985,7 @@ dependencies = [
  "serde_json",
  "slotmap",
  "sonic-rs",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -2028,7 +2051,7 @@ dependencies = [
  "serde_json",
  "slotmap",
  "sonic-rs",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -2099,6 +2122,7 @@ dependencies = [
  "once_cell",
  "open",
  "parking_lot",
+ "portable-pty",
  "pulldown-cmark",
  "same-file",
  "serde",
@@ -2111,10 +2135,12 @@ dependencies = [
  "tempfile",
  "termina",
  "termini",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "toml",
+ "vt100",
+ "vte",
 ]
 
 [[package]]
@@ -2185,7 +2211,7 @@ dependencies = [
  "steel-core",
  "tempfile",
  "termina",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "toml",
@@ -2563,6 +2589,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,6 +2740,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2906,6 +2950,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
 ]
 
 [[package]]
@@ -3412,6 +3477,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,6 +3517,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -3607,7 +3693,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror",
+ "thiserror 2.0.18",
  "zmij",
 ]
 
@@ -3858,7 +3944,7 @@ dependencies = [
  "lazy-regex",
  "minimad",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-width 0.1.12",
 ]
 
@@ -3907,11 +3993,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4075,7 +4181,7 @@ dependencies = [
  "libloading 0.8.9",
  "regex-cursor",
  "ropey",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4184,6 +4290,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,6 +4310,39 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vt100"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+dependencies = [
+ "itoa",
+ "log",
+ "unicode-width 0.1.12",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "arrayvec 0.7.7",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"
@@ -4471,6 +4616,15 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -93,6 +93,14 @@ steel-doc = { git = "https://github.com/mattwparas/steel.git", optional = true }
 globset = "0.4.16"
 dashmap = "6.2"
 
+# terminal buffers: PTY spawning/IO + ANSI/VT parsing into a screen grid
+portable-pty = "0.9"
+vt100 = "0.15"
+# same VTE parser vt100 uses internally; used directly to detect terminal
+# capability queries (DA/DSR) vt100 itself silently drops, so we can answer
+# them instead of leaving the child program waiting on a reply that never comes
+vte = "0.11"
+
 parking_lot.workspace = true
 
 [target.'cfg(windows)'.dependencies]

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -922,6 +922,11 @@ impl Application {
                             token,
                             value: lsp::ProgressParamsValue::WorkDone(work),
                         } = params;
+                        let token_str = match &token {
+                            lsp::NumberOrString::Number(n) => n.to_string(),
+                            lsp::NumberOrString::String(s) => s.clone(),
+                        };
+                        let server_name = language_server!().name().to_string();
                         let (title, message, percentage) = match &work {
                             lsp::WorkDoneProgress::Begin(lsp::WorkDoneProgressBegin {
                                 title,
@@ -944,8 +949,8 @@ impl Application {
                                     }
                                     self.editor.clear_status();
                                     helix_event::dispatch(helix_view::events::LspProgressUpdate {
-                                        server_id,
-                                        token: token.to_string(),
+                                        server_name: server_name.clone(),
+                                        token: token_str.clone(),
                                         kind: "end".to_string(),
                                         title: None,
                                         message: None,
@@ -988,8 +993,8 @@ impl Application {
                                 self.lsp_progress
                                     .begin(server_id, token.clone(), begin_status);
                                 helix_event::dispatch(helix_view::events::LspProgressUpdate {
-                                    server_id,
-                                    token: token.to_string(),
+                                    server_name: server_name.clone(),
+                                    token: token_str.clone(),
                                     kind: "begin".to_string(),
                                     title: fire_title,
                                     message: fire_message,
@@ -1002,8 +1007,8 @@ impl Application {
                                 self.lsp_progress
                                     .update(server_id, token.clone(), report_status);
                                 helix_event::dispatch(helix_view::events::LspProgressUpdate {
-                                    server_id,
-                                    token: token.to_string(),
+                                    server_name: server_name.clone(),
+                                    token: token_str.clone(),
                                     kind: "report".to_string(),
                                     title: None,
                                     message: fire_message,
@@ -1017,8 +1022,8 @@ impl Application {
                                     editor_view.spinners_mut().get_or_create(server_id).stop();
                                 };
                                 helix_event::dispatch(helix_view::events::LspProgressUpdate {
-                                    server_id,
-                                    token: token.to_string(),
+                                    server_name: server_name.clone(),
+                                    token: token_str.clone(),
                                     kind: "end".to_string(),
                                     title: None,
                                     message: fire_message,

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -142,6 +142,16 @@ impl Application {
 
         compositor.push(editor_view);
 
+        // The tree has no view yet at this point (`Tree::new` leaves `focus`
+        // pointing at the root container), so anything relying on "there is
+        // a current buffer" - `current!`/`current_ref!` and everything built
+        // on them - panics if touched before one exists. The init script
+        // below runs arbitrary plugin code that may well do exactly that
+        // (e.g. a hook or a buffer-creation helper called eagerly at load
+        // time), so give it a real place to land. It's cleaned up below,
+        // once the real initial buffer(s) are open, if nothing claimed it.
+        let placeholder_doc_id = editor.new_file(Action::VerticalSplit);
+
         let mut jobs = Jobs::new();
         {
             let syn_loader = editor.syn_loader.clone();
@@ -252,6 +262,19 @@ impl Application {
             editor
                 .new_file_from_stdin(Action::VerticalSplit)
                 .unwrap_or_else(|_| editor.new_file(Action::VerticalSplit));
+        }
+
+        // The real initial buffer(s) are open now, so the placeholder from
+        // before the init script is redundant - unless a hook or other
+        // eagerly-run plugin code actually used it, in which case leave it
+        // alone (same "empty scratch buffer" check `Action::Replace` already
+        // uses elsewhere: unmodified and never given a path).
+        if let Some(doc) = editor.document(placeholder_doc_id) {
+            if !doc.is_modified() && doc.path().is_none() {
+                // `force: false` re-asserts that safety check; it should
+                // never actually reject here given the check above.
+                let _ = editor.close_document(placeholder_doc_id, false);
+            }
         }
 
         #[cfg(windows)]

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -943,6 +943,14 @@ impl Application {
                                         editor_view.spinners_mut().get_or_create(server_id).stop();
                                     }
                                     self.editor.clear_status();
+                                    helix_event::dispatch(helix_view::events::LspProgressUpdate {
+                                        server_id,
+                                        token: token.to_string(),
+                                        kind: "end".to_string(),
+                                        title: None,
+                                        message: None,
+                                        percentage: None,
+                                    });
 
                                     // we want to render to clear any leftover spinners or messages
                                     return;
@@ -974,18 +982,48 @@ impl Application {
 
                         match work {
                             lsp::WorkDoneProgress::Begin(begin_status) => {
+                                let fire_title = Some(begin_status.title.clone());
+                                let fire_message = begin_status.message.clone();
+                                let fire_percentage = begin_status.percentage;
                                 self.lsp_progress
                                     .begin(server_id, token.clone(), begin_status);
+                                helix_event::dispatch(helix_view::events::LspProgressUpdate {
+                                    server_id,
+                                    token: token.to_string(),
+                                    kind: "begin".to_string(),
+                                    title: fire_title,
+                                    message: fire_message,
+                                    percentage: fire_percentage,
+                                });
                             }
                             lsp::WorkDoneProgress::Report(report_status) => {
+                                let fire_message = report_status.message.clone();
+                                let fire_percentage = report_status.percentage;
                                 self.lsp_progress
                                     .update(server_id, token.clone(), report_status);
+                                helix_event::dispatch(helix_view::events::LspProgressUpdate {
+                                    server_id,
+                                    token: token.to_string(),
+                                    kind: "report".to_string(),
+                                    title: None,
+                                    message: fire_message,
+                                    percentage: fire_percentage,
+                                });
                             }
-                            lsp::WorkDoneProgress::End(_) => {
+                            lsp::WorkDoneProgress::End(end_status) => {
+                                let fire_message = end_status.message.clone();
                                 self.lsp_progress.end_progress(server_id, &token);
                                 if !self.lsp_progress.is_progressing(server_id) {
                                     editor_view.spinners_mut().get_or_create(server_id).stop();
                                 };
+                                helix_event::dispatch(helix_view::events::LspProgressUpdate {
+                                    server_id,
+                                    token: token.to_string(),
+                                    kind: "end".to_string(),
+                                    title: None,
+                                    message: fire_message,
+                                    percentage: None,
+                                });
                             }
                         }
                     }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -185,6 +185,7 @@ impl Application {
             // handle it (e.g. a file-manager buffer bound to a global "oil"
             // command) - falling back to the native picker if none is
             // defined.
+            let mut directory_handled_by_plugin = false;
             if let Some((first, _)) = files_it.next_if(|(p, _)| p.is_dir()) {
                 let dir_arg = first.to_string_lossy().into_owned();
                 let handled = {
@@ -203,7 +204,9 @@ impl Application {
                     )
                 };
 
-                if !handled {
+                if handled {
+                    directory_handled_by_plugin = true;
+                } else {
                     let picker = ui::file_picker(&editor, first);
                     compositor.push(Box::new(overlaid(picker)));
                 }
@@ -275,7 +278,10 @@ impl Application {
                     let (view, doc) = current!(editor);
                     align_view(doc, view, Align::Center);
                 }
-            } else {
+            } else if !directory_handled_by_plugin {
+                // Only the native-picker path needs a backing scratch buffer
+                // to float over - a plugin that opened a real buffer for the
+                // directory (e.g. oil) doesn't need a second one alongside it.
                 editor.new_file(Action::VerticalSplit);
             }
         } else if stdin().is_terminal() || cfg!(feature = "integration") {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -181,10 +181,32 @@ impl Application {
         } else if !args.files.is_empty() {
             let mut files_it = args.files.into_iter().peekable();
 
-            // If the first file is a directory, skip it and open a picker
+            // If the first file is a directory, skip it and let a plugin
+            // handle it (e.g. a file-manager buffer bound to a global "oil"
+            // command) - falling back to the native picker if none is
+            // defined.
             if let Some((first, _)) = files_it.next_if(|(p, _)| p.is_dir()) {
-                let picker = ui::file_picker(&editor, first);
-                compositor.push(Box::new(overlaid(picker)));
+                let dir_arg = first.to_string_lossy().into_owned();
+                let handled = {
+                    let mut cx = crate::commands::Context {
+                        register: None,
+                        count: std::num::NonZeroUsize::new(1),
+                        editor: &mut editor,
+                        callback: Vec::new(),
+                        on_next_key_callback: None,
+                        jobs: &mut jobs,
+                    };
+                    crate::commands::ScriptingEngine::call_function_by_name(
+                        &mut cx,
+                        "oil",
+                        vec![std::borrow::Cow::Owned(dir_arg)],
+                    )
+                };
+
+                if !handled {
+                    let picker = ui::file_picker(&editor, first);
+                    compositor.push(Box::new(overlaid(picker)));
+                }
             }
 
             // If there are any more files specified, open them

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -70,6 +70,7 @@ use crate::{
     compositor::{self, Component, Compositor},
     filter_picker_entry,
     job::Callback,
+    term_pty,
     ui::{self, overlay::overlaid, Picker, PickerColumn, Popup, Prompt, PromptEvent},
 };
 
@@ -5985,6 +5986,20 @@ fn transpose_view(cx: &mut Context) {
 ///
 /// Maintain the current view (both the cursor's position and view in document).
 fn split(editor: &mut Editor, action: Action) {
+    let (_, doc) = current!(editor);
+    // A terminal buffer is one `Document` backed by one live PTY - splitting
+    // it doesn't give two independent terminals the way splitting a shell
+    // pane in tmux would, it gives two views of the exact same process,
+    // both accepting keystrokes. Beyond being useless (there's no scroll
+    // position to view independently either - see `Document::is_terminal_buffer`
+    // pinning both to the same spot), closing either split's view closes
+    // the shared document, which kills the process for both - surprising
+    // if the user only meant to close one pane. Simplest to just refuse.
+    if term_pty::is_terminal(doc.id()) {
+        editor.set_error("can't split a terminal buffer");
+        return;
+    }
+
     let (view, doc) = current!(editor);
     let id = doc.id();
     let selection = doc.selection(view.id).clone();

--- a/helix-term/src/commands/engine/steel/buffer-types.scm
+++ b/helix-term/src/commands/engine/steel/buffer-types.scm
@@ -1,0 +1,143 @@
+;; A small contract for plugins that own buffers as their UI (a directory
+;; listing, a diff view, a picker-as-buffer, ...) instead of hand-rolling a
+;; component. Every primitive this builds on - buffer-set-text!,
+;; buffer-set-keymap!, the document-* hooks - already works standalone; this
+;; just gives plugins a shared way to say "here is a kind of buffer I own,
+;; here is what its lifecycle looks like" once, instead of every plugin
+;; registering its own global document-* hook and filtering it by hand.
+;;
+;; This is for *synthetic* buffers a plugin creates and fully owns (via
+;; `create-buffer!`), not for tagging regular file buffers by filetype - for
+;; that, `(keymap (extension ...))` already does the job.
+
+(require "helix/static.scm")
+(require "helix/editor.scm")
+(require "helix/keymaps.scm")
+(require "helix/commands.scm")
+
+(provide define-buffer-type
+         create-buffer!
+         buffer-type)
+
+;; type-name (string) -> handlers hash: 'keymap 'on-enter 'on-write 'on-change 'on-close
+(define *buffer-type-registry* (hash))
+;; doc-id (usize) -> type-name (string), set by create-buffer!
+(define *buffer-type-tags* (hash))
+
+(define (%hash-get-or-false hm key)
+  (if (hash-contains? hm key) (hash-get hm key) #false))
+
+(define (register-buffer-type! name handlers)
+  (set! *buffer-type-registry* (hash-insert *buffer-type-registry* name handlers)))
+
+(define (get-buffer-type-handlers name)
+  (%hash-get-or-false *buffer-type-registry* name))
+
+;;@doc
+;; Look up the registered buffer type a document was tagged with via
+;; `create-buffer!`, or `#false` if it isn't a plugin-owned buffer.
+;;
+;; ```scheme
+;; (buffer-type doc-id) -> (or string? #false)
+;; ```
+(define (buffer-type doc-id)
+  (%hash-get-or-false *buffer-type-tags* (doc-id->usize doc-id)))
+
+(define (%tag-buffer! doc-id type-name)
+  (set! *buffer-type-tags*
+        (hash-insert *buffer-type-tags* (doc-id->usize doc-id) type-name)))
+
+;;@doc
+;; Declare a reusable buffer type: a keymap plus lifecycle callbacks that
+;; `create-buffer!` wires up for every buffer created with this type name.
+;; `handlers` is a hash literal; every key is optional.
+;;
+;; ```scheme
+;; (define-buffer-type name handlers) -> void?
+;;
+;; name : string?
+;; handlers : hash?
+;;   'keymap    : keymap?                       ;; as built by the `keymap` macro
+;;   'on-enter  : (-> doc-id? any?)
+;;   'on-write  : (-> doc-id? (or string? #false) any?)
+;;   'on-change : (-> doc-id? string? any?)
+;;   'on-close  : (-> doc-id? any?)
+;; ```
+;;
+;; `on-write` mirrors the `document-will-save` hook: return `#true` to mark
+;; the save handled (skipping the built-in write), any other value to let it
+;; proceed normally. A handler that takes over the save is responsible for
+;; calling `(buffer-mark-saved!)` itself if it wants the modified indicator
+;; cleared.
+;;
+;; # Example
+;; ```scheme
+;; (define-buffer-type
+;;  "oil"
+;;  (hash 'keymap (keymap (normal (ret ":oil-open-under-cursor") (q ":oil-close")))
+;;        'on-enter (lambda (doc-id) (oil-refresh! doc-id))
+;;        'on-write (lambda (doc-id path) (oil-apply-changes! doc-id) #true)))
+;;
+;; (create-buffer! "oil" (oil-render-listing "."))
+;; ```
+(define (define-buffer-type name handlers)
+  (register-buffer-type! name handlers))
+
+;;@doc
+;; Create a new scratch buffer of a type declared with `define-buffer-type`:
+;; opens it, applies the type's keymap (if any), sets its initial text (if
+;; given), tags it so the shared hooks below route lifecycle events to this
+;; type's callbacks, then calls the type's `on-enter` (if any).
+;;
+;; ```scheme
+;; (create-buffer! type-name [initial-text]) -> DocumentId?
+;;
+;; type-name : string?
+;; initial-text : string?
+;; ```
+(define (create-buffer! type-name . initial-text)
+  (define handlers (get-buffer-type-handlers type-name))
+  (unless handlers
+    (error (string-append "create-buffer!: no buffer type registered under " type-name)))
+
+  (new)
+  (define doc-id (editor->doc-id (editor-focus)))
+
+  (%tag-buffer! doc-id type-name)
+
+  (when (hash-contains? handlers 'keymap)
+    (buffer-set-keymap! doc-id (hash-get handlers 'keymap)))
+
+  (unless (null? initial-text)
+    (buffer-set-text! (car initial-text)))
+
+  (define on-enter (%hash-get-or-false handlers 'on-enter))
+  (when on-enter (on-enter doc-id))
+
+  doc-id)
+
+;; Wired once here rather than per-plugin: each dispatches to the owning
+;; type's handler (if any) based on the buffer's tag, so individual plugins
+;; never register their own global document-* hook and filter it themselves.
+
+(register-hook 'document-will-save
+                (lambda (doc-id path)
+                  (define type-name (buffer-type doc-id))
+                  (define handlers (and type-name (get-buffer-type-handlers type-name)))
+                  (define on-write (and handlers (%hash-get-or-false handlers 'on-write)))
+                  (if on-write (on-write doc-id path) #false)))
+
+(register-hook 'document-changed
+                (lambda (doc-id old-text)
+                  (define type-name (buffer-type doc-id))
+                  (define handlers (and type-name (get-buffer-type-handlers type-name)))
+                  (define on-change (and handlers (%hash-get-or-false handlers 'on-change)))
+                  (when on-change (on-change doc-id old-text))))
+
+(register-hook 'document-closed
+                (lambda (closed-event)
+                  (define doc-id (doc-closed-id closed-event))
+                  (define type-name (buffer-type doc-id))
+                  (define handlers (and type-name (get-buffer-type-handlers type-name)))
+                  (define on-close (and handlers (%hash-get-or-false handlers 'on-close)))
+                  (when on-close (on-close doc-id))))

--- a/helix-term/src/commands/engine/steel/editor.scm
+++ b/helix-term/src/commands/engine/steel/editor.scm
@@ -318,6 +318,11 @@
 ;;Set the editor clipping at the top.
 (define set-editor-clip-top! helix.set-editor-clip-top!)
 
+(provide set-editor-terminal-has-focus!)
+;;@doc
+;;When true, suppresses helix view cursor rendering so only the PTY cursor is visible.
+(define set-editor-terminal-has-focus! helix.set-editor-terminal-has-focus!)
+
 (provide set-editor-clip-right!)
 ;;@doc
 ;;Set the editor clipping at the right.

--- a/helix-term/src/commands/engine/steel/editor.scm
+++ b/helix-term/src/commands/engine/steel/editor.scm
@@ -23,6 +23,7 @@
 ;; * 'document-focus-lost
 ;; * 'selection-did-change
 ;; * 'document-opened
+;; * 'document-will-save
 ;; * 'document-saved
 ;; * 'document-changed
 ;; * 'document-closed
@@ -87,6 +88,28 @@
 ;; ## document-opened
 ;;
 ;; Expects a function with one argument to accept the doc id of the document that was just opened.
+;;
+;; ## document-will-save
+;;
+;; Fired synchronously, before a `:w`-family command writes the document to
+;; disk - unlike every other hook, which runs deferred and can't affect
+;; anything the caller does next. Expects a function of two arguments, the
+;; doc id and the resolved save path (or `#false` if none could be
+;; resolved). If the callback returns `#true`, the save is considered fully
+;; handled and the built-in write is skipped for this invocation; any other
+;; return value lets the write proceed normally. This is the primitive for a
+;; plugin-owned buffer (a directory listing, a diff view, ...) that wants
+;; `:w` to run its own logic instead of writing the buffer's literal text to
+;; `path` - the callback is responsible for whatever "saved" should mean for
+;; that buffer, including clearing its modified state if desired.
+;;
+;; ```scheme
+;; (register-hook 'document-will-save
+;;                 (lambda (doc-id path)
+;;                   (if (my-plugin-buffer? doc-id)
+;;                       (begin (my-plugin-apply! doc-id) #true)
+;;                       #false)))
+;; ```
 ;;
 ;; ## document-saved
 ;;

--- a/helix-term/src/commands/engine/steel/editor.scm
+++ b/helix-term/src/commands/engine/steel/editor.scm
@@ -291,6 +291,13 @@
 ;;Set the name of a scratch buffer.
 (define set-scratch-buffer-name! helix.set-scratch-buffer-name!)
 
+(provide set-bufferline-name!)
+;;@doc
+;;Set the short bufferline-tab label for a scratch buffer, independent of
+;;set-scratch-buffer-name! (which is shown in the statusline and can be
+;;long, e.g. a full directory path).
+(define set-bufferline-name! helix.set-bufferline-name!)
+
 (provide set-buffer-uri!)
 ;;@doc
 ;;Set the URI of the buffer

--- a/helix-term/src/commands/engine/steel/editor.scm
+++ b/helix-term/src/commands/engine/steel/editor.scm
@@ -298,6 +298,21 @@
 ;;long, e.g. a full directory path).
 (define set-bufferline-name! helix.set-bufferline-name!)
 
+(provide document-set-bufferline-name!)
+;;@doc
+;;Same as `set-bufferline-name!`, but by doc-id rather than the current
+;;buffer — needed right after `term-buffer-spawn!`/`term-buffer-spawn-with-shell!`
+;;(see their docs in `helix/static.scm`), since the buffer they return
+;;isn't current yet.
+;;
+;;```scheme
+;;(document-set-bufferline-name! doc-id name) -> void?
+;;
+;;doc-id : doc-id?
+;;name : string?
+;;```
+(define document-set-bufferline-name! helix.document-set-bufferline-name!)
+
 (provide set-buffer-uri!)
 ;;@doc
 ;;Set the URI of the buffer

--- a/helix-term/src/commands/engine/steel/keymaps.scm
+++ b/helix-term/src/commands/engine/steel/keymaps.scm
@@ -9,7 +9,8 @@
          deep-copy-global-keybindings
          keymap
          query-keymap
-         query-global-keymap)
+         query-global-keymap
+         buffer-set-keymap!)
 
 (define (get-doc name)
   ;; Do our best - if the identifier doesn't exist (for example, if we're checking)
@@ -44,6 +45,35 @@
 ;; Insert a value into the reverse buffer map
 (define (*reverse-buffer-map-insert* key value)
   (helix.keymaps.#%add-reverse-mapping key value))
+
+;;@doc
+;; Bind `keymap` to this specific document instance, independent of its file
+;; extension. This is the primitive plugin-owned buffers (file explorers, diff
+;; views, or any other "buffer as UI" plugin) need to give each buffer its own
+;; keys without affecting every other buffer of the same filetype - unlike
+;; `(keymap (extension ...))`, which applies to every buffer sharing that
+;; extension.
+;;
+;; The keymap only applies while `doc-id` stays open; closing the buffer does
+;; not need to be paired with any cleanup call.
+;;
+;; ```scheme
+;; (buffer-set-keymap! doc-id keymap) -> void?
+;;
+;; doc-id : DocumentId?
+;; keymap : hash? ;; As constructed via the `keymap` macro, e.g. `(keymap (normal ...))`
+;; ```
+;;
+;; # Examples
+;; ```scheme
+;; (buffer-set-keymap! (editor->doc-id (editor-focus))
+;;                      (keymap (normal (ret ":oil-open-under-cursor")
+;;                                      (q ":oil-close"))))
+;; ```
+(define (buffer-set-keymap! doc-id km)
+  (define label (number->string (doc-id->usize doc-id)))
+  (helix.keymaps.#%add-extension-or-labeled-keymap label (merge-keybindings (empty-map) km))
+  (*reverse-buffer-map-insert* (doc-id->usize doc-id) label))
 
 ;; Marshall values in and out of keybindings, referencing the associated values
 ;; within steel

--- a/helix-term/src/commands/engine/steel/misc.scm
+++ b/helix-term/src/commands/engine/steel/misc.scm
@@ -336,7 +336,7 @@
 ;;@doc
 ;; Register a hook that fires on every LSP WorkDoneProgress begin/report/end notification.
 ;; The callback receives six arguments:
-;;   server-id  : integer — the language server ID
+;;   server-name : string  — the language server name
 ;;   token      : string  — the progress token (number or string from the server)
 ;;   kind       : string  — "begin" | "report" | "end"
 ;;   title      : string? — task title (only present on "begin")

--- a/helix-term/src/commands/engine/steel/misc.scm
+++ b/helix-term/src/commands/engine/steel/misc.scm
@@ -332,3 +332,33 @@
 ;; pattern : string?
 ;; input-list : (list? string?)
 (define fuzzy-match helix.fuzzy-match)
+
+(provide steel-mode)
+;;@doc
+;;Returns the active Steel mode name, or #false if no Steel mode is active.
+(define steel-mode helix.steel-mode)
+
+(provide set-steel-mode!)
+;;@doc
+;;Set the active Steel mode by name. The name is shown in the statusline.
+;;Use register-steel-mode-keymap! to bind keys for the mode.
+(define set-steel-mode! helix.set-steel-mode!)
+
+(provide unset-steel-mode!)
+;;@doc
+;;Clear the active Steel mode.
+(define unset-steel-mode! helix.unset-steel-mode!)
+
+(provide register-steel-mode-keymap!)
+;;@doc
+;;Register a keymap for a named Steel mode. The keymap takes priority over
+;;the default helix keybindings when that mode is active.
+;;
+;;```scheme
+;;(register-steel-mode-keymap! name keymap)
+;;```
+;;
+;;name : string?
+;;keymap : keymap?
+(define (register-steel-mode-keymap! name keymap)
+  (helix.register-steel-mode-keymap! name (value->jsexpr-string keymap)))

--- a/helix-term/src/commands/engine/steel/misc.scm
+++ b/helix-term/src/commands/engine/steel/misc.scm
@@ -332,3 +332,21 @@
 ;; pattern : string?
 ;; input-list : (list? string?)
 (define fuzzy-match helix.fuzzy-match)
+
+;;@doc
+;; Register a hook that fires on every LSP WorkDoneProgress begin/report/end notification.
+;; The callback receives six arguments:
+;;   server-id  : integer — the language server ID
+;;   token      : string  — the progress token (number or string from the server)
+;;   kind       : string  — "begin" | "report" | "end"
+;;   title      : string? — task title (only present on "begin")
+;;   message    : string? — optional human-readable message
+;;   percentage : integer? — optional 0-100 completion percentage
+;;
+;; Example:
+;; ```scheme
+;; (register-hook! 'lsp-progress
+;;   (lambda (server-id token kind title message percentage)
+;;     (when (equal? kind "begin")
+;;       (display (string-append "LSP: " (or title token) "\n")))))
+;; ```

--- a/helix-term/src/commands/engine/steel/misc.scm
+++ b/helix-term/src/commands/engine/steel/misc.scm
@@ -380,3 +380,35 @@
 ;;keymap : keymap?
 (define (register-steel-mode-keymap! name keymap)
   (helix.register-steel-mode-keymap! name (value->jsexpr-string keymap)))
+
+(provide selection-char-ranges)
+;;@doc
+;;Returns a list of (start . end) char-index pairs for every range in the current selection.
+(define selection-char-ranges helix.selection-char-ranges)
+
+(provide set-document-highlights!)
+;;@doc
+;;Set script-defined highlights for a namespace.
+;;
+;;```scheme
+;;(set-document-highlights! namespace ranges scope)
+;;```
+;;
+;;namespace : string? — unique key for this highlight group (e.g. "yank")
+;;ranges    : (listof (cons int? int?)) — list of (start . end) char-index pairs
+;;scope     : string? — theme scope to use (e.g. "ui.selection", "ui.highlight")
+(define set-document-highlights! helix.set-document-highlights!)
+
+(provide clear-document-highlights!)
+;;@doc
+;;Clear script highlights for the given namespace.
+;;
+;;```scheme
+;;(clear-document-highlights! namespace)
+;;```
+(define clear-document-highlights! helix.clear-document-highlights!)
+
+(provide clear-all-document-highlights!)
+;;@doc
+;;Clear all script highlights on the current document.
+(define clear-all-document-highlights! helix.clear-all-document-highlights!)

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -4650,8 +4650,7 @@ fn configure_engine_impl(mut engine: Engine) -> Engine {
                     let text = doc.text();
                     if row.line_start < text.len_lines() {
                         let start = text.line_to_char(row.line_start);
-                        let end = text.line_to_char((row.line_end + 1).min(text.len_lines()));
-                        doc.set_selection(view.id, Selection::single(start, end));
+                        doc.set_selection(view.id, Selection::point(start));
                         if action.align_view(view, doc.id()) {
                             helix_view::align_view(doc, view, helix_view::Align::Center);
                         }

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -699,11 +699,7 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "current-selection-object", current_selection)
         .register_fn_with_ctx(CTX, "get-helix-cwd", get_helix_cwd)
         .register_fn_with_ctx(CTX, "move-window-far-left", move_window_to_the_left)
-        .register_fn_with_ctx(CTX, "move-window-far-right", move_window_to_the_right)
-        .register_fn_with_ctx(CTX, "selection-char-ranges", selection_char_ranges)
-        .register_fn_with_ctx(CTX, "set-document-highlights!", set_script_highlights)
-        .register_fn_with_ctx(CTX, "clear-document-highlights!", clear_script_highlights)
-        .register_fn_with_ctx(CTX, "clear-all-document-highlights!", clear_all_script_highlights);
+        .register_fn_with_ctx(CTX, "move-window-far-right", move_window_to_the_right);
 
     module
         .register_fn("selection->primary-index", |sel: Selection| {
@@ -1557,6 +1553,13 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "editor->text", document_id_to_text)
         .register_fn_with_ctx(CTX, "editor-document->path", document_path)
         .register_fn_with_ctx(CTX, "register->value", cx_register_value)
+        .register_fn_with_ctx(
+            CTX,
+            "set-editor-terminal-has-focus!",
+            |cx: &mut Context, focused: bool| {
+                cx.editor.steel_terminal_has_focus = focused;
+            },
+        )
         .register_fn_with_ctx(
             CTX,
             "set-editor-clip-right!",
@@ -4091,7 +4094,11 @@ fn load_misc_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "steel-mode", get_custom_mode)
         .register_fn_with_ctx(CTX, "set-steel-mode!", set_custom_mode)
         .register_fn_with_ctx(CTX, "unset-steel-mode!", unset_custom_mode)
-        .register_fn("register-steel-mode-keymap!", register_steel_mode_keymap);
+        .register_fn("register-steel-mode-keymap!", register_steel_mode_keymap)
+        .register_fn_with_ctx(CTX, "selection-char-ranges", selection_char_ranges)
+        .register_fn_with_ctx(CTX, "set-document-highlights!", set_script_highlights)
+        .register_fn_with_ctx(CTX, "clear-document-highlights!", clear_script_highlights)
+        .register_fn_with_ctx(CTX, "clear-all-document-highlights!", clear_all_script_highlights);
 
     if generate_sources {
         generate_module("misc.scm", &builtin_misc_module);
@@ -4534,6 +4541,53 @@ fn configure_engine_impl(mut engine: Engine) -> Engine {
 
             for file in values {
                 if injector.push(PathBuf::from(file)).is_err() {
+                    break;
+                }
+            }
+
+            WrappedDynComponent {
+                inner: Some(Box::new(ui::overlay::overlaid(picker))),
+            }
+        },
+    );
+
+    // String picker: like #%exp-picker but items are arbitrary strings, not file paths.
+    // The callback receives the selected string as its sole argument.
+    engine.register_fn(
+        "#%string-picker",
+        |values: Vec<String>, callback_fn: SteelVal| -> WrappedDynComponent {
+            let columns = [PickerColumn::new("item", |item: &String, _: &()| {
+                item.as_str().into()
+            })];
+
+            let rooted = callback_fn.as_rooted();
+
+            let picker = ui::Picker::new(columns, 0, [], (), move |cx, item: &String, _action| {
+                let selected = item.clone();
+                with_ephemeral_context(cx, |ctx| {
+                    let cloned_func = rooted.value();
+                    enter_engine(|guard| {
+                        if let Err(e) = guard
+                            .with_mut_reference::<Context, Context>(ctx)
+                            .consume_once(move |engine, args| {
+                                let context = args.into_iter().next().unwrap();
+                                engine.update_value(CTX, context);
+                                engine.call_function_with_args(
+                                    cloned_func.clone(),
+                                    vec![SteelVal::StringV(selected.into())],
+                                )
+                            })
+                        {
+                            present_error_inside_engine_context(ctx, guard, e);
+                        }
+                    });
+                });
+            });
+
+            let injector = picker.injector();
+
+            for item in values {
+                if injector.push(item).is_err() {
                     break;
                 }
             }

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -5713,8 +5713,9 @@ fn term_buffer_spawn_impl(
     // Callers name the buffer via `document-set-bufferline-name!` with the
     // returned doc-id, since `set-bufferline-name!`'s "current buffer"
     // convention no longer points at it yet.
-    let new_doc =
+    let mut new_doc =
         helix_view::Document::default(cx.editor.config.clone(), cx.editor.syn_loader.clone());
+    new_doc.is_terminal_buffer = true;
     let doc_id = cx.editor.new_document(new_doc);
 
     crate::term_pty::PtySession::spawn(doc_id, view_id, rows, cols, Some(command), shell)?;

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -3566,7 +3566,7 @@ fn register_lsp_progress(
     register_hook!(move |event: &mut LspProgressUpdate| {
         let cloned_func = rooted.value().clone();
         let args = [
-            event.server_id.into_steelval().unwrap(),
+            event.server_name.clone().into_steelval().unwrap(),
             event.token.clone().into_steelval().unwrap(),
             event.kind.clone().into_steelval().unwrap(),
             event.title.clone().into_steelval().unwrap(),

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -4284,6 +4284,15 @@ fn fuzzy_match(pattern: SteelString, items: SteelVal) -> Vec<SteelVal> {
     Vec::new()
 }
 
+/// A row for `#%location-picker`: a display label plus a file location to
+/// preview (and jump to) at a line range.
+struct LocationRow {
+    label: String,
+    path: PathBuf,
+    line_start: usize,
+    line_end: usize,
+}
+
 fn configure_engine_impl(mut engine: Engine) -> Engine {
     log::info!("Loading engine!");
 
@@ -4593,6 +4602,62 @@ fn configure_engine_impl(mut engine: Engine) -> Engine {
                     break;
                 }
             }
+
+            WrappedDynComponent {
+                inner: Some(Box::new(ui::overlay::overlaid(picker))),
+            }
+        },
+    );
+
+    // Location picker: native picker over (label, path, line-start, line-end)
+    // rows. Previews the file scrolled to and highlighting the line range, and
+    // on selection opens the file and jumps to it. Same look/behaviour as the
+    // built-in diagnostics / global-search pickers.
+    engine.register_fn(
+        "#%location-picker",
+        |labels: Vec<String>,
+         paths: Vec<String>,
+         line_starts: Vec<usize>,
+         line_ends: Vec<usize>|
+         -> WrappedDynComponent {
+            let rows: Vec<LocationRow> = labels
+                .into_iter()
+                .zip(paths)
+                .zip(line_starts)
+                .zip(line_ends)
+                .map(|(((label, path), line_start), line_end)| LocationRow {
+                    label,
+                    path: PathBuf::from(path),
+                    line_start,
+                    line_end,
+                })
+                .collect();
+
+            let columns = [PickerColumn::new("location", |row: &LocationRow, _: &()| {
+                row.label.as_str().into()
+            })];
+
+            let picker = ui::Picker::new(columns, 0, rows, (), move |cx, row: &LocationRow, action| {
+                if let Err(e) = cx.editor.open(&row.path, action) {
+                    cx.editor
+                        .set_error(format!("Failed to open '{}': {}", row.path.display(), e));
+                    return;
+                }
+                let (view, doc) = current!(cx.editor);
+                let text = doc.text();
+                if row.line_start >= text.len_lines() {
+                    return;
+                }
+                let start = text.line_to_char(row.line_start);
+                let end = text.line_to_char((row.line_end + 1).min(text.len_lines()));
+                doc.set_selection(view.id, Selection::single(start, end));
+                if action.align_view(view, doc.id()) {
+                    helix_view::align_view(doc, view, helix_view::Align::Center);
+                }
+            })
+            .with_preview(|_editor, row: &LocationRow| {
+                Some((PathOrId::Path(row.path.as_path()), Some((row.line_start, row.line_end))))
+            });
 
             WrappedDynComponent {
                 inner: Some(Box::new(ui::overlay::overlaid(picker))),

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -688,6 +688,14 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "replace-selection-with", replace_selection)
         .register_fn_with_ctx(CTX, "buffer-set-text!", buffer_set_text)
         .register_fn_with_ctx(CTX, "buffer-mark-saved!", buffer_mark_saved)
+        .register_fn_with_ctx(CTX, "term-buffer-spawn!", term_buffer_spawn)
+        .register_fn_with_ctx(
+            CTX,
+            "term-buffer-spawn-with-shell!",
+            term_buffer_spawn_with_shell,
+        )
+        .register_fn("term-buffer-send!", term_buffer_send)
+        .register_fn("term-buffer-alive?", term_buffer_alive)
         .register_fn_with_ctx(
             CTX,
             "enqueue-expression-in-engine",
@@ -3619,10 +3627,7 @@ fn register_document_focus_lost(
     Ok(SteelVal::Void).into()
 }
 
-fn register_lsp_progress(
-    generation: usize,
-    rooted: RootedSteelVal,
-) -> steel::UnRecoverableResult {
+fn register_lsp_progress(generation: usize, rooted: RootedSteelVal) -> steel::UnRecoverableResult {
     register_hook!(move |event: &mut LspProgressUpdate| {
         let cloned_func = rooted.value().clone();
         let args = [
@@ -4150,7 +4155,11 @@ fn load_misc_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "selection-char-ranges", selection_char_ranges)
         .register_fn_with_ctx(CTX, "set-document-highlights!", set_script_highlights)
         .register_fn_with_ctx(CTX, "clear-document-highlights!", clear_script_highlights)
-        .register_fn_with_ctx(CTX, "clear-all-document-highlights!", clear_all_script_highlights);
+        .register_fn_with_ctx(
+            CTX,
+            "clear-all-document-highlights!",
+            clear_all_script_highlights,
+        );
 
     if generate_sources {
         generate_module("misc.scm", &builtin_misc_module);
@@ -4696,47 +4705,60 @@ fn configure_engine_impl(mut engine: Engine) -> Engine {
                 })
                 .collect();
 
-            let columns = [PickerColumn::new("location", |row: &LocationRow, _: &()| {
-                row.label.as_str().into()
-            })];
+            let columns = [PickerColumn::new(
+                "location",
+                |row: &LocationRow, _: &()| row.label.as_str().into(),
+            )];
 
             let rooted = callback_fn.as_rooted();
-            let picker = ui::Picker::new(columns, 0, rows, (), move |cx, row: &LocationRow, action| {
-                if let Err(e) = cx.editor.open(&row.path, action) {
-                    cx.editor
-                        .set_error(format!("Failed to open '{}': {}", row.path.display(), e));
-                    return;
-                }
-                {
-                    let (view, doc) = current!(cx.editor);
-                    let text = doc.text();
-                    if row.line_start < text.len_lines() {
-                        let start = text.line_to_char(row.line_start);
-                        doc.set_selection(view.id, Selection::point(start));
-                        if action.align_view(view, doc.id()) {
-                            helix_view::align_view(doc, view, helix_view::Align::Center);
+            let picker = ui::Picker::new(
+                columns,
+                0,
+                rows,
+                (),
+                move |cx, row: &LocationRow, action| {
+                    if let Err(e) = cx.editor.open(&row.path, action) {
+                        cx.editor.set_error(format!(
+                            "Failed to open '{}': {}",
+                            row.path.display(),
+                            e
+                        ));
+                        return;
+                    }
+                    {
+                        let (view, doc) = current!(cx.editor);
+                        let text = doc.text();
+                        if row.line_start < text.len_lines() {
+                            let start = text.line_to_char(row.line_start);
+                            doc.set_selection(view.id, Selection::point(start));
+                            if action.align_view(view, doc.id()) {
+                                helix_view::align_view(doc, view, helix_view::Align::Center);
+                            }
                         }
                     }
-                }
-                // Run the Steel callback (no args) after the jump.
-                with_ephemeral_context(cx, |ctx| {
-                    let cloned_func = rooted.value();
-                    enter_engine(|guard| {
-                        if let Err(e) = guard
-                            .with_mut_reference::<Context, Context>(ctx)
-                            .consume_once(move |engine, args| {
-                                let context = args.into_iter().next().unwrap();
-                                engine.update_value(CTX, context);
-                                engine.call_function_with_args(cloned_func.clone(), Vec::new())
-                            })
-                        {
-                            present_error_inside_engine_context(ctx, guard, e);
-                        }
+                    // Run the Steel callback (no args) after the jump.
+                    with_ephemeral_context(cx, |ctx| {
+                        let cloned_func = rooted.value();
+                        enter_engine(|guard| {
+                            if let Err(e) = guard
+                                .with_mut_reference::<Context, Context>(ctx)
+                                .consume_once(move |engine, args| {
+                                    let context = args.into_iter().next().unwrap();
+                                    engine.update_value(CTX, context);
+                                    engine.call_function_with_args(cloned_func.clone(), Vec::new())
+                                })
+                            {
+                                present_error_inside_engine_context(ctx, guard, e);
+                            }
+                        });
                     });
-                });
-            })
+                },
+            )
             .with_preview(|_editor, row: &LocationRow| {
-                Some((PathOrId::Path(row.path.as_path()), Some((row.line_start, row.line_end))))
+                Some((
+                    PathOrId::Path(row.path.as_path()),
+                    Some((row.line_start, row.line_end)),
+                ))
             });
 
             WrappedDynComponent {
@@ -5651,6 +5673,70 @@ fn buffer_mark_saved(cx: &mut Context) {
     doc.set_last_saved_revision(rev, std::time::SystemTime::now());
 }
 
+// Spawn `command` (run as `shell -c command`) as a new terminal buffer
+// replacing the current view's document — same machinery as the native
+// `:term-buffer` command, but for an arbitrary program instead of an
+// interactive shell. Lets plugins (lazygit.hx, sidekick.hx, ...) embed a
+// specific program as a real buffer, with bufferline/split/buffer-nav for
+// free, instead of the old floating-component terminal.
+fn term_buffer_spawn_impl(
+    cx: &mut Context,
+    command: &str,
+    shell: Option<&str>,
+) -> anyhow::Result<DocumentId> {
+    cx.editor.new_file(Action::Replace);
+
+    let (view, doc) = current!(cx.editor);
+    let doc_id = doc.id();
+    let view_id = view.id;
+    let area = view.inner_area(doc);
+    // See the matching comment in `terminal_new` (commands/typed.rs): one
+    // column of slack so a full-width pty line doesn't sit exactly on
+    // Helix's soft-wrap boundary.
+    let (rows, cols) = (area.height.max(1), area.width.saturating_sub(1).max(1));
+
+    crate::term_pty::PtySession::spawn(doc_id, view_id, rows, cols, Some(command), shell)?;
+
+    cx.editor.mode = Mode::Insert;
+
+    Ok(doc_id)
+}
+
+fn term_buffer_spawn(cx: &mut Context, command: SteelString) -> anyhow::Result<DocumentId> {
+    term_buffer_spawn_impl(cx, command.as_str(), None)
+}
+
+// Same as `term_buffer_spawn`, but running `command` under an explicitly
+// chosen shell instead of `$SHELL`. For commands using syntax that isn't
+// portable across shells (e.g. POSIX `(...)` subshell grouping, which fish
+// doesn't understand the same way bash does) — pin `bash` rather than
+// gamble on what the user's login shell happens to be.
+fn term_buffer_spawn_with_shell(
+    cx: &mut Context,
+    command: SteelString,
+    shell: SteelString,
+) -> anyhow::Result<DocumentId> {
+    term_buffer_spawn_impl(cx, command.as_str(), Some(shell.as_str()))
+}
+
+// Write raw bytes to a terminal buffer's child process stdin. No implicit
+// newline appended — same convention the old `pty-process-send-command` had;
+// callers append `\r` themselves.
+fn term_buffer_send(doc_id: DocumentId, text: SteelString) {
+    if let Some(session) = crate::term_pty::get(doc_id) {
+        session.write_input(text.as_bytes());
+    }
+}
+
+// Whether `doc-id` is a still-running terminal buffer. A terminal buffer
+// closes itself (and this becomes false) the moment its child process
+// exits — see `term_pty::cleanup`, wired to the `document-closed` hook —
+// so this doubles as "is the process still alive", not just "does this
+// document still exist".
+fn term_buffer_alive(doc_id: DocumentId) -> bool {
+    crate::term_pty::is_terminal(doc_id)
+}
+
 // TODO: Remove this!
 fn move_window_to_the_left(cx: &mut Context) {
     while cx
@@ -5914,14 +6000,17 @@ pub fn add_typed_inlay_hint(
         let last_line = first_visible_line
             .saturating_add(view_height.saturating_mul(2))
             .min(len_lines);
-        DocumentInlayHints::empty_with_id(DocumentInlayHintsId { first_line, last_line })
+        DocumentInlayHints::empty_with_id(DocumentInlayHintsId {
+            first_line,
+            last_line,
+        })
     });
 
     let annotation = InlineAnnotation::new(char_index, completion.to_string());
     match kind.as_str() {
-        "type"      => new_inlay_hints.type_inlay_hints.push(annotation),
+        "type" => new_inlay_hints.type_inlay_hints.push(annotation),
         "parameter" => new_inlay_hints.parameter_inlay_hints.push(annotation),
-        _           => new_inlay_hints.other_inlay_hints.push(annotation),
+        _ => new_inlay_hints.other_inlay_hints.push(annotation),
     }
 
     let id = new_inlay_hints.id;
@@ -5956,7 +6045,10 @@ pub fn add_scoped_inlay_hint(
         let last_line = first_visible_line
             .saturating_add(view_height.saturating_mul(2))
             .min(len_lines);
-        DocumentInlayHints::empty_with_id(DocumentInlayHintsId { first_line, last_line })
+        DocumentInlayHints::empty_with_id(DocumentInlayHintsId {
+            first_line,
+            last_line,
+        })
     });
 
     let annotation = InlineAnnotation::new(char_index, completion.to_string());

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -694,6 +694,7 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
             "term-buffer-spawn-with-shell!",
             term_buffer_spawn_with_shell,
         )
+        .register_fn("term-buffer-hide-gutter!", crate::term_pty::set_hide_gutter)
         .register_fn("term-buffer-send!", term_buffer_send)
         .register_fn("term-buffer-alive?", term_buffer_alive)
         .register_fn_with_ctx(
@@ -1505,6 +1506,11 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "editor-doc-in-view?", cx_is_document_in_view)
         .register_fn_with_ctx(CTX, "set-scratch-buffer-name!", set_scratch_buffer_name)
         .register_fn_with_ctx(CTX, "set-bufferline-name!", set_bufferline_name)
+        .register_fn_with_ctx(
+            CTX,
+            "document-set-bufferline-name!",
+            document_set_bufferline_name,
+        )
         // Get the last saved time of the document
         .register_fn_with_ctx(
             CTX,
@@ -5158,6 +5164,15 @@ fn set_bufferline_name(cx: &mut Context, name: String) {
     }
 }
 
+// Same as `set_bufferline_name`, but by doc-id rather than "current buffer"
+// — needed for a terminal buffer between `term-buffer-spawn!` returning and
+// its first reveal, since it isn't the current buffer yet at that point.
+fn document_set_bufferline_name(cx: &mut Context, doc_id: DocumentId, name: String) {
+    if let Some(doc) = cx.editor.documents.get_mut(&doc_id) {
+        doc.bufferline_name = Some(name);
+    }
+}
+
 fn set_buffer_uri(cx: &mut Context, uri: SteelString) -> anyhow::Result<()> {
     let current_focus = cx.editor.tree.focus;
     let view = cx.editor.tree.get(current_focus);
@@ -5684,10 +5699,7 @@ fn term_buffer_spawn_impl(
     command: &str,
     shell: Option<&str>,
 ) -> anyhow::Result<DocumentId> {
-    cx.editor.new_file(Action::Replace);
-
     let (view, doc) = current!(cx.editor);
-    let doc_id = doc.id();
     let view_id = view.id;
     let area = view.inner_area(doc);
     // See the matching comment in `terminal_new` (commands/typed.rs): one
@@ -5695,9 +5707,17 @@ fn term_buffer_spawn_impl(
     // Helix's soft-wrap boundary.
     let (rows, cols) = (area.height.max(1), area.width.saturating_sub(1).max(1));
 
-    crate::term_pty::PtySession::spawn(doc_id, view_id, rows, cols, Some(command), shell)?;
+    // Created but not switched to yet: term_pty::PtySession reveals it once
+    // the child process has actually produced something to show, instead of
+    // flashing an empty buffer during its own shell-fork/exec/init latency.
+    // Callers name the buffer via `document-set-bufferline-name!` with the
+    // returned doc-id, since `set-bufferline-name!`'s "current buffer"
+    // convention no longer points at it yet.
+    let new_doc =
+        helix_view::Document::default(cx.editor.config.clone(), cx.editor.syn_loader.clone());
+    let doc_id = cx.editor.new_document(new_doc);
 
-    cx.editor.mode = Mode::Insert;
+    crate::term_pty::PtySession::spawn(doc_id, view_id, rows, cols, Some(command), shell)?;
 
     Ok(doc_id)
 }

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -33,7 +33,7 @@ use helix_view::{
     },
     events::{
         DocumentDidChange, DocumentDidClose, DocumentDidOpen, DocumentFocusLost, DocumentSaved,
-        SelectionDidChange,
+        LspProgressUpdate, SelectionDidChange,
     },
     extension::{document_id_to_usize, steel_implementations::CustomStatusElement},
     graphics::CursorKind,
@@ -3388,6 +3388,7 @@ fn register_hook(event_kind: String, callback_fn: SteelVal) -> steel::UnRecovera
         "document-saved" => register_document_saved(generation, rooted),
         "document-changed" => register_document_changed(generation, rooted),
         "document-closed" => register_document_closed(generation, rooted),
+        "lsp-progress" => register_lsp_progress(generation, rooted),
         _ => steelerr!(Generic => "Unable to register hook: Unknown event type: {}", event_kind)
             .into(),
     }
@@ -3553,6 +3554,27 @@ fn register_document_focus_lost(
             construct_callback(generation, cloned_func, [doc_id.into_steelval().unwrap()]);
         job::dispatch_blocking_jobs(callback);
 
+        Ok(())
+    });
+    Ok(SteelVal::Void).into()
+}
+
+fn register_lsp_progress(
+    generation: usize,
+    rooted: RootedSteelVal,
+) -> steel::UnRecoverableResult {
+    register_hook!(move |event: &mut LspProgressUpdate| {
+        let cloned_func = rooted.value().clone();
+        let args = [
+            event.server_id.into_steelval().unwrap(),
+            event.token.clone().into_steelval().unwrap(),
+            event.kind.clone().into_steelval().unwrap(),
+            event.title.clone().into_steelval().unwrap(),
+            event.message.clone().into_steelval().unwrap(),
+            event.percentage.into_steelval().unwrap(),
+        ];
+        let callback = construct_callback(generation, cloned_func, args);
+        job::dispatch_blocking_jobs(callback);
         Ok(())
     });
     Ok(SteelVal::Void).into()

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -1496,6 +1496,7 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "editor-set-mode!", cx_set_mode)
         .register_fn_with_ctx(CTX, "editor-doc-in-view?", cx_is_document_in_view)
         .register_fn_with_ctx(CTX, "set-scratch-buffer-name!", set_scratch_buffer_name)
+        .register_fn_with_ctx(CTX, "set-bufferline-name!", set_bufferline_name)
         // Get the last saved time of the document
         .register_fn_with_ctx(
             CTX,
@@ -5117,6 +5118,21 @@ fn set_scratch_buffer_name(cx: &mut Context, name: String) {
 
     if let Some(current_doc) = current_doc {
         current_doc.name = Some(name);
+    }
+}
+
+// A short label for the bufferline tab specifically - `name` (set via
+// set-scratch-buffer-name!) is shown in the statusline and can reasonably be
+// long (e.g. a full directory path), but the bufferline only has room for a
+// short tab title.
+fn set_bufferline_name(cx: &mut Context, name: String) {
+    let current_focus = cx.editor.tree.focus;
+    let Some(doc) = cx.editor.tree.try_get(current_focus).map(|view| view.doc) else {
+        return;
+    };
+
+    if let Some(current_doc) = cx.editor.documents.get_mut(&doc) {
+        current_doc.bufferline_name = Some(name);
     }
 }
 

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -4618,7 +4618,8 @@ fn configure_engine_impl(mut engine: Engine) -> Engine {
         |labels: Vec<String>,
          paths: Vec<String>,
          line_starts: Vec<usize>,
-         line_ends: Vec<usize>|
+         line_ends: Vec<usize>,
+         callback_fn: SteelVal|
          -> WrappedDynComponent {
             let rows: Vec<LocationRow> = labels
                 .into_iter()
@@ -4637,23 +4638,41 @@ fn configure_engine_impl(mut engine: Engine) -> Engine {
                 row.label.as_str().into()
             })];
 
+            let rooted = callback_fn.as_rooted();
             let picker = ui::Picker::new(columns, 0, rows, (), move |cx, row: &LocationRow, action| {
                 if let Err(e) = cx.editor.open(&row.path, action) {
                     cx.editor
                         .set_error(format!("Failed to open '{}': {}", row.path.display(), e));
                     return;
                 }
-                let (view, doc) = current!(cx.editor);
-                let text = doc.text();
-                if row.line_start >= text.len_lines() {
-                    return;
+                {
+                    let (view, doc) = current!(cx.editor);
+                    let text = doc.text();
+                    if row.line_start < text.len_lines() {
+                        let start = text.line_to_char(row.line_start);
+                        let end = text.line_to_char((row.line_end + 1).min(text.len_lines()));
+                        doc.set_selection(view.id, Selection::single(start, end));
+                        if action.align_view(view, doc.id()) {
+                            helix_view::align_view(doc, view, helix_view::Align::Center);
+                        }
+                    }
                 }
-                let start = text.line_to_char(row.line_start);
-                let end = text.line_to_char((row.line_end + 1).min(text.len_lines()));
-                doc.set_selection(view.id, Selection::single(start, end));
-                if action.align_view(view, doc.id()) {
-                    helix_view::align_view(doc, view, helix_view::Align::Center);
-                }
+                // Run the Steel callback (no args) after the jump.
+                with_ephemeral_context(cx, |ctx| {
+                    let cloned_func = rooted.value();
+                    enter_engine(|guard| {
+                        if let Err(e) = guard
+                            .with_mut_reference::<Context, Context>(ctx)
+                            .consume_once(move |engine, args| {
+                                let context = args.into_iter().next().unwrap();
+                                engine.update_value(CTX, context);
+                                engine.call_function_with_args(cloned_func.clone(), Vec::new())
+                            })
+                        {
+                            present_error_inside_engine_context(ctx, guard, e);
+                        }
+                    });
+                });
             })
             .with_preview(|_editor, row: &LocationRow| {
                 Some((PathOrId::Path(row.path.as_path()), Some((row.line_start, row.line_end))))

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -699,7 +699,11 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "current-selection-object", current_selection)
         .register_fn_with_ctx(CTX, "get-helix-cwd", get_helix_cwd)
         .register_fn_with_ctx(CTX, "move-window-far-left", move_window_to_the_left)
-        .register_fn_with_ctx(CTX, "move-window-far-right", move_window_to_the_right);
+        .register_fn_with_ctx(CTX, "move-window-far-right", move_window_to_the_right)
+        .register_fn_with_ctx(CTX, "selection-char-ranges", selection_char_ranges)
+        .register_fn_with_ctx(CTX, "set-document-highlights!", set_script_highlights)
+        .register_fn_with_ctx(CTX, "clear-document-highlights!", clear_script_highlights)
+        .register_fn_with_ctx(CTX, "clear-all-document-highlights!", clear_all_script_highlights);
 
     module
         .register_fn("selection->primary-index", |sel: Selection| {
@@ -4620,6 +4624,68 @@ fn get_highlighted_text(cx: &mut Context) -> String {
 fn current_selection(cx: &mut Context) -> Selection {
     let (view, doc) = current_ref!(cx.editor);
     doc.selection(view.id).clone()
+}
+
+fn selection_char_ranges(cx: &mut Context) -> Vec<(usize, usize)> {
+    let (view, doc) = current_ref!(cx.editor);
+    doc.selection(view.id)
+        .iter()
+        .map(|r| (r.from(), r.to()))
+        .collect()
+}
+
+fn set_script_highlights(
+    cx: &mut Context,
+    namespace: SteelString,
+    ranges: Vec<SteelVal>,
+    scope: SteelString,
+) -> anyhow::Result<()> {
+    let ranges: anyhow::Result<Vec<std::ops::Range<usize>>> = ranges
+        .into_iter()
+        .map(|v| match v {
+            SteelVal::ListV(pair) => {
+                let mut iter = pair.iter();
+                let start = iter
+                    .next()
+                    .and_then(|v| v.as_isize())
+                    .ok_or_else(|| anyhow::anyhow!("range start must be an integer"))?
+                    as usize;
+                let end = iter
+                    .next()
+                    .and_then(|v| v.as_isize())
+                    .ok_or_else(|| anyhow::anyhow!("range end must be an integer"))?
+                    as usize;
+                Ok(start..end)
+            }
+            SteelVal::Pair(pair) => {
+                let start = pair
+                    .car()
+                    .as_isize()
+                    .ok_or_else(|| anyhow::anyhow!("range start must be an integer"))?
+                    as usize;
+                let end = pair
+                    .cdr()
+                    .as_isize()
+                    .ok_or_else(|| anyhow::anyhow!("range end must be an integer"))?
+                    as usize;
+                Ok(start..end)
+            }
+            other => anyhow::bail!("expected (start . end) pair, got {:?}", other),
+        })
+        .collect();
+    let (_, doc) = current!(cx.editor);
+    doc.set_script_highlights(namespace.to_string(), scope.to_string(), ranges?);
+    Ok(())
+}
+
+fn clear_script_highlights(cx: &mut Context, namespace: SteelString) {
+    let (_, doc) = current!(cx.editor);
+    doc.clear_script_highlights(&namespace);
+}
+
+fn clear_all_script_highlights(cx: &mut Context) {
+    let (_, doc) = current!(cx.editor);
+    doc.clear_all_script_highlights();
 }
 
 fn set_selection(cx: &mut Context, selection: Selection) {

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -4089,6 +4089,7 @@ fn load_misc_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "await-callback", await_value)
         .register_fn_with_ctx(CTX, "add-inlay-hint", add_inlay_hint)
         .register_fn_with_ctx(CTX, "add-typed-inlay-hint", add_typed_inlay_hint)
+        .register_fn_with_ctx(CTX, "add-scoped-inlay-hint", add_scoped_inlay_hint)
         .register_fn_with_ctx(CTX, "remove-inlay-hint", remove_inlay_hint)
         .register_fn_with_ctx(CTX, "remove-inlay-hint-by-id", remove_inlay_hint_by_id)
         .register_fn("fuzzy-match", fuzzy_match)
@@ -5738,6 +5739,47 @@ pub fn add_typed_inlay_hint(
         "parameter" => new_inlay_hints.parameter_inlay_hints.push(annotation),
         _           => new_inlay_hints.other_inlay_hints.push(annotation),
     }
+
+    let id = new_inlay_hints.id;
+    doc.set_inlay_hints(view_id, new_inlay_hints);
+    Some((id.first_line, id.last_line))
+}
+
+/// Add an inlay hint styled by an explicit theme scope (e.g. "diff.plus",
+/// "diagnostic.warning"). The scope is resolved to a highlight at render time,
+/// so the color follows the active theme — unlike add-typed-inlay-hint, which
+/// is limited to the fixed ui.virtual.inlay-hint.{type,parameter} scopes.
+pub fn add_scoped_inlay_hint(
+    cx: &mut Context,
+    char_index: usize,
+    completion: SteelString,
+    scope: SteelString,
+) -> Option<(usize, usize)> {
+    let view_id = cx.editor.tree.focus;
+    if !cx.editor.tree.contains(view_id) {
+        return None;
+    }
+    let view = cx.editor.tree.get(view_id);
+    let doc_id = cx.editor.tree.get(view_id).doc;
+    let doc = cx.editor.documents.get_mut(&doc_id)?;
+    let mut new_inlay_hints = doc.inlay_hints(view_id).cloned().unwrap_or_else(|| {
+        let doc_text = doc.text();
+        let len_lines = doc_text.len_lines();
+        let view_height = view.inner_height();
+        let first_visible_line =
+            doc_text.char_to_line(doc.view_offset(view_id).anchor.min(doc_text.len_chars()));
+        let first_line = first_visible_line.saturating_sub(view_height);
+        let last_line = first_visible_line
+            .saturating_add(view_height.saturating_mul(2))
+            .min(len_lines);
+        DocumentInlayHints::empty_with_id(DocumentInlayHintsId { first_line, last_line })
+    });
+
+    let annotation = InlineAnnotation::new(char_index, completion.to_string());
+    new_inlay_hints.scoped_inlay_hints.push(annotation);
+    new_inlay_hints
+        .scoped_inlay_hint_scopes
+        .push(scope.to_string());
 
     let id = new_inlay_hints.id;
     doc.set_inlay_hints(view_id, new_inlay_hints);

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -427,6 +427,36 @@ fn reset_buffer_extension_keymap() {
     guard.reverse.clear();
 }
 
+/// Per-name keymaps for Steel-defined modes. When a steel mode is active,
+/// `handle_keymap_event_impl` checks this map first; unrecognised keys fall
+/// through to the buffer/extension keymap.
+pub static STEEL_MODE_KEYBINDING_MAP: Lazy<Mutex<HashMap<String, EmbeddedKeyMap>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+fn set_custom_mode(cx: &mut Context, name: SteelString) {
+    cx.editor.steel_mode = Some(name.to_string());
+}
+
+fn unset_custom_mode(cx: &mut Context) {
+    cx.editor.steel_mode = None;
+}
+
+fn get_custom_mode(cx: &mut Context) -> SteelVal {
+    match cx.editor.steel_mode.as_deref() {
+        Some(s) => SteelVal::StringV(s.into()),
+        None => SteelVal::BoolV(false),
+    }
+}
+
+fn register_steel_mode_keymap(name: SteelString, keymap: String) -> anyhow::Result<()> {
+    let embedded = string_to_embedded_keymap(keymap)?;
+    STEEL_MODE_KEYBINDING_MAP
+        .lock()
+        .unwrap()
+        .insert(name.to_string(), embedded);
+    Ok(())
+}
+
 enum LspKind {
     Call(RootedSteelVal),
     Notification(RootedSteelVal),
@@ -1966,6 +1996,22 @@ impl SteelScriptingEngine {
         cx: &mut Context,
         event: KeyEvent,
     ) -> Option<KeymapResult> {
+        // Steel mode keymaps act as priority overrides: if the active steel mode
+        // has registered a keymap that contains this (mode, key) pair, use it.
+        // Unrecognised keys fall through to the buffer/extension keymap below.
+        if let Some(ref mode_name) = cx.editor.steel_mode.clone() {
+            let km_guard = STEEL_MODE_KEYBINDING_MAP.lock().unwrap();
+            if let Some(keymap) = km_guard.get(mode_name) {
+                if keymap.0.contains_key(&mode) {
+                    let result = editor.keymaps.get_with_map(&keymap.0, mode, event);
+                    drop(km_guard);
+                    if !matches!(result, KeymapResult::NotFound) {
+                        return Some(result);
+                    }
+                }
+            }
+        }
+
         let extension = {
             let current_focus = cx.editor.tree.focus;
             let view = cx.editor.tree.get(current_focus);
@@ -4015,7 +4061,11 @@ fn load_misc_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "add-inlay-hint", add_inlay_hint)
         .register_fn_with_ctx(CTX, "remove-inlay-hint", remove_inlay_hint)
         .register_fn_with_ctx(CTX, "remove-inlay-hint-by-id", remove_inlay_hint_by_id)
-        .register_fn("fuzzy-match", fuzzy_match);
+        .register_fn("fuzzy-match", fuzzy_match)
+        .register_fn_with_ctx(CTX, "steel-mode", get_custom_mode)
+        .register_fn_with_ctx(CTX, "set-steel-mode!", set_custom_mode)
+        .register_fn_with_ctx(CTX, "unset-steel-mode!", unset_custom_mode)
+        .register_fn("register-steel-mode-keymap!", register_steel_mode_keymap);
 
     if generate_sources {
         generate_module("misc.scm", &builtin_misc_module);

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -78,7 +78,10 @@ use crate::{
     commands::{insert, TYPABLE_COMMAND_LIST},
     compositor::{self, Component, Compositor},
     config::Config,
-    events::{OnModeSwitch, PostCommand, PostInsertChar, TerminalFocusGained, TerminalFocusLost},
+    events::{
+        DocumentWillSave, OnModeSwitch, PostCommand, PostInsertChar, TerminalFocusGained,
+        TerminalFocusLost,
+    },
     job::{self, Callback, Jobs},
     keymap::{self, merge_keys, KeyTrie, KeymapResult, MappableCommand},
     ui::{self, picker::PathOrId, PickerColumn, Popup, Prompt, PromptEvent},
@@ -683,6 +686,8 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
         )
         .register_fn_with_ctx(CTX, "regex-selection", regex_selection)
         .register_fn_with_ctx(CTX, "replace-selection-with", replace_selection)
+        .register_fn_with_ctx(CTX, "buffer-set-text!", buffer_set_text)
+        .register_fn_with_ctx(CTX, "buffer-mark-saved!", buffer_mark_saved)
         .register_fn_with_ctx(
             CTX,
             "enqueue-expression-in-engine",
@@ -3438,6 +3443,7 @@ fn register_hook(event_kind: String, callback_fn: SteelVal) -> steel::UnRecovera
         "document-focus-lost" => register_document_focus_lost(generation, rooted),
         "selection-did-change" => register_selection_did_change(generation, rooted),
         "document-opened" => register_document_opened(generation, rooted),
+        "document-will-save" => register_document_will_save(generation, rooted),
         "document-saved" => register_document_saved(generation, rooted),
         "document-changed" => register_document_changed(generation, rooted),
         "document-closed" => register_document_closed(generation, rooted),
@@ -3641,6 +3647,49 @@ fn register_post_command(generation: usize, rooted: RootedSteelVal) -> steel::Un
             rooted.value().clone(),
             &mut [event.command.name().into_steelval().unwrap()],
         );
+        Ok(())
+    });
+    Ok(SteelVal::Void).into()
+}
+
+/// Unlike the other hooks, this one is dispatched synchronously and its
+/// return value is observed: the callback returning `#true` cancels the
+/// save (the callback is expected to have handled it itself), matching
+/// `document-will-save`'s "was this handled" contract described in its doc
+/// comment. Every other hook here discards the callback's return value and
+/// runs through the (deferred) job queue instead, which can't work for a
+/// hook that needs to short-circuit a decision the caller is about to make.
+fn register_document_will_save(
+    generation: usize,
+    rooted: RootedSteelVal,
+) -> steel::UnRecoverableResult {
+    register_hook!(move |event: &mut DocumentWillSave<'_, '_>| {
+        if !is_current_generation(generation) {
+            return Ok(());
+        }
+
+        let doc_id = event.doc;
+        let path = event
+            .path
+            .map(|p| p.to_string_lossy().to_string())
+            .into_steelval()
+            .unwrap();
+
+        let result = enter_engine(|guard| {
+            call_with_context_and_args(
+                guard,
+                event.cx,
+                rooted.value().clone(),
+                &mut [doc_id.into_steelval().unwrap(), path],
+            )
+        });
+
+        match result {
+            Ok(SteelVal::BoolV(true)) => *event.cancel = true,
+            Ok(_) => {}
+            Err(e) => event.cx.editor.set_error(e.to_string()),
+        }
+
         Ok(())
     });
     Ok(SteelVal::Void).into()
@@ -4138,6 +4187,17 @@ pub fn load_ext_api(engine: &mut Engine, generate_sources: bool) {
     engine.register_steel_module("helix/ext.scm".to_string(), ext_api.to_string());
 }
 
+pub fn load_buffer_types_api(engine: &mut Engine, generate_sources: bool) {
+    let buffer_types_api = include_str!("buffer-types.scm");
+    if generate_sources {
+        generate_module("buffer-types.scm", buffer_types_api);
+    }
+    engine.register_steel_module(
+        "helix/buffer-types.scm".to_string(),
+        buffer_types_api.to_string(),
+    );
+}
+
 // Note: This implementation is aligned with what the steel language server
 // expects. This shouldn't stay here, but for alpha purposes its fine.
 pub fn steel_lsp_home_dir() -> PathBuf {
@@ -4173,6 +4233,7 @@ pub fn configure_builtin_sources(engine: &mut Engine, generate_sources: bool) {
     load_high_level_theme_api(engine, generate_sources);
     load_high_level_keymap_api(engine, generate_sources);
     load_ext_api(engine, generate_sources);
+    load_buffer_types_api(engine, generate_sources);
 
     if generate_sources {
         configure_lsp_globals();
@@ -5548,6 +5609,26 @@ fn replace_selection(cx: &mut Context, value: String) {
         });
 
     doc.apply(&transaction, view.id);
+}
+
+// Replace the entire contents of the current buffer with `text`, diffing against the
+// existing content so undo history and mapped state (selections, diagnostics, etc.)
+// stay coherent instead of being nuked by a delete-then-insert.
+fn buffer_set_text(cx: &mut Context, text: SteelString) {
+    let (view, doc) = current!(cx.editor);
+    let new_text = helix_core::Rope::from(text.as_str());
+    let transaction = helix_core::diff::compare_ropes(doc.text(), &new_text);
+    doc.apply(&transaction, view.id);
+}
+
+// Mark the current buffer as saved at its current revision, without writing
+// anything to disk. For a `document-will-save` hook that takes over a save
+// itself (see `helix/buffer-types.scm`), this is how it clears the modified
+// indicator afterward, same as a real write would have.
+fn buffer_mark_saved(cx: &mut Context) {
+    let (_, doc) = current!(cx.editor);
+    let rev = doc.get_current_revision();
+    doc.set_last_saved_revision(rev, std::time::SystemTime::now());
 }
 
 // TODO: Remove this!

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -5099,7 +5099,9 @@ fn get_init_scm_path() -> String {
 // TODO:
 fn current_path(cx: &mut Context) -> Option<String> {
     let current_focus = cx.editor.tree.focus;
-    let view = cx.editor.tree.get(current_focus);
+    // `tree.focus` can transiently point at an already-removed view during
+    // teardown (e.g. quit) - guard instead of unwrapping.
+    let view = cx.editor.tree.try_get(current_focus)?;
     let doc = &view.doc;
     // Lifetime of this needs to be tied to the existing document
     let current_doc = cx.editor.documents.get(doc);
@@ -5140,8 +5142,10 @@ fn cx_current_focus(cx: &mut Context) -> helix_view::ViewId {
     cx.editor.tree.focus
 }
 
-fn cx_get_document_id(cx: &mut Context, view_id: helix_view::ViewId) -> DocumentId {
-    cx.editor.tree.get(view_id).doc
+fn cx_get_document_id(cx: &mut Context, view_id: helix_view::ViewId) -> Option<DocumentId> {
+    // `view_id` may no longer exist in the tree - e.g. `tree.focus` can be left
+    // pointing at an already-removed view transiently during teardown (quit).
+    cx.editor.tree.try_get(view_id).map(|view| view.doc)
 }
 
 fn document_id_to_text(cx: &mut Context, doc_id: DocumentId) -> Option<SteelRopeSlice> {

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -4088,6 +4088,7 @@ fn load_misc_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "helix-await-callback", await_value)
         .register_fn_with_ctx(CTX, "await-callback", await_value)
         .register_fn_with_ctx(CTX, "add-inlay-hint", add_inlay_hint)
+        .register_fn_with_ctx(CTX, "add-typed-inlay-hint", add_typed_inlay_hint)
         .register_fn_with_ctx(CTX, "remove-inlay-hint", remove_inlay_hint)
         .register_fn_with_ctx(CTX, "remove-inlay-hint-by-id", remove_inlay_hint_by_id)
         .register_fn("fuzzy-match", fuzzy_match)
@@ -5698,6 +5699,48 @@ pub fn add_inlay_hint(
 
     doc.set_inlay_hints(view_id, new_inlay_hints);
 
+    Some((id.first_line, id.last_line))
+}
+
+// "add-typed-inlay-hint" — like add-inlay-hint but kind selects the theme scope:
+//   "type"      → ui.virtual.inlay-hint.type
+//   "parameter" → ui.virtual.inlay-hint.parameter
+//   anything else → ui.virtual.inlay-hint (same as add-inlay-hint)
+pub fn add_typed_inlay_hint(
+    cx: &mut Context,
+    char_index: usize,
+    completion: SteelString,
+    kind: SteelString,
+) -> Option<(usize, usize)> {
+    let view_id = cx.editor.tree.focus;
+    if !cx.editor.tree.contains(view_id) {
+        return None;
+    }
+    let view = cx.editor.tree.get(view_id);
+    let doc_id = cx.editor.tree.get(view_id).doc;
+    let doc = cx.editor.documents.get_mut(&doc_id)?;
+    let mut new_inlay_hints = doc.inlay_hints(view_id).cloned().unwrap_or_else(|| {
+        let doc_text = doc.text();
+        let len_lines = doc_text.len_lines();
+        let view_height = view.inner_height();
+        let first_visible_line =
+            doc_text.char_to_line(doc.view_offset(view_id).anchor.min(doc_text.len_chars()));
+        let first_line = first_visible_line.saturating_sub(view_height);
+        let last_line = first_visible_line
+            .saturating_add(view_height.saturating_mul(2))
+            .min(len_lines);
+        DocumentInlayHints::empty_with_id(DocumentInlayHintsId { first_line, last_line })
+    });
+
+    let annotation = InlineAnnotation::new(char_index, completion.to_string());
+    match kind.as_str() {
+        "type"      => new_inlay_hints.type_inlay_hints.push(annotation),
+        "parameter" => new_inlay_hints.parameter_inlay_hints.push(annotation),
+        _           => new_inlay_hints.other_inlay_hints.push(annotation),
+    }
+
+    let id = new_inlay_hints.id;
+    doc.set_inlay_hints(view_id, new_inlay_hints);
     Some((id.first_line, id.last_line))
 }
 

--- a/helix-term/src/commands/engine/steel/static.scm
+++ b/helix-term/src/commands/engine/steel/static.scm
@@ -68,11 +68,19 @@
 (provide term-buffer-spawn!)
 ;;@doc
 ;;Spawn `command` (run as `$SHELL -c command`, so `cd dir && exec prog`
-;;style chaining works) as a new terminal buffer, replacing the current
-;;view's document. The buffer's rope is kept live-synced to the child
-;;process's PTY output — it's a real `Document`, so bufferline, splits, and
-;;buffer-next/previous all work on it for free. Returns the new buffer's
-;;doc-id.
+;;style chaining works) as a new terminal buffer. The buffer's rope is kept
+;;live-synced to the child process's PTY output — it's a real `Document`,
+;;so bufferline, splits, and buffer-next/previous all work on it for free.
+;;Returns the new buffer's doc-id.
+;;
+;;The buffer isn't switched to immediately: it's revealed (replacing the
+;;current view's document, same as `term-buffer-spawn!` used to do right
+;;away) the moment the child process produces its first real output,
+;;rather than flashing an empty buffer during its own startup latency
+;;(shell fork/exec, then its own init). Because of this, the returned
+;;doc-id is *not* the current buffer yet — use `document-set-bufferline-name!`
+;;with it directly rather than `set-bufferline-name!`, which only affects
+;;whatever buffer is current right now.
 ;;
 ;;`$SHELL` isn't always bash/POSIX-sh — if `command` uses syntax that
 ;;isn't portable across shells (e.g. `(...)` subshell grouping, which
@@ -132,6 +140,20 @@
 ;;doc-id : doc-id?
 ;;```
 (define term-buffer-alive? helix.static.term-buffer-alive?)
+
+(provide term-buffer-hide-gutter!)
+;;@doc
+;;Whether terminal buffers hide the line-number gutter. Defaults to `#true`
+;;— a full-width blank/loading terminal reads as "a terminal", whereas one
+;;with Helix's usual gutter furniture reads as "an empty file". Affects
+;;every terminal buffer, not a specific one.
+;;
+;;```scheme
+;;(term-buffer-hide-gutter! hide) -> void?
+;;
+;;hide : bool?
+;;```
+(define term-buffer-hide-gutter! helix.static.term-buffer-hide-gutter!)
 
 (provide enqueue-expression-in-engine)
 ;;@doc

--- a/helix-term/src/commands/engine/steel/static.scm
+++ b/helix-term/src/commands/engine/steel/static.scm
@@ -43,6 +43,28 @@
 ;;Replace the existing selection with the given string
 (define replace-selection-with helix.static.replace-selection-with)
 
+(provide buffer-set-text!)
+;;@doc
+;;Replace the entire contents of the current buffer with `text`. The new content
+;;is diffed against the existing buffer so undo history stays a single coherent
+;;step and unrelated state (selections, diagnostics) is only remapped, not reset.
+;;
+;;```scheme
+;;(buffer-set-text! text) -> void?
+;;```
+(define buffer-set-text! helix.static.buffer-set-text!)
+
+(provide buffer-mark-saved!)
+;;@doc
+;;Mark the current buffer as saved at its current revision, without writing
+;;anything to disk. Used to clear the modified indicator after a
+;;`document-will-save` hook has taken over a save itself.
+;;
+;;```scheme
+;;(buffer-mark-saved!) -> void?
+;;```
+(define buffer-mark-saved! helix.static.buffer-mark-saved!)
+
 (provide enqueue-expression-in-engine)
 ;;@doc
 ;;Enqueue an expression to run at the top level context,

--- a/helix-term/src/commands/engine/steel/static.scm
+++ b/helix-term/src/commands/engine/steel/static.scm
@@ -65,6 +65,74 @@
 ;;```
 (define buffer-mark-saved! helix.static.buffer-mark-saved!)
 
+(provide term-buffer-spawn!)
+;;@doc
+;;Spawn `command` (run as `$SHELL -c command`, so `cd dir && exec prog`
+;;style chaining works) as a new terminal buffer, replacing the current
+;;view's document. The buffer's rope is kept live-synced to the child
+;;process's PTY output — it's a real `Document`, so bufferline, splits, and
+;;buffer-next/previous all work on it for free. Returns the new buffer's
+;;doc-id.
+;;
+;;`$SHELL` isn't always bash/POSIX-sh — if `command` uses syntax that
+;;isn't portable across shells (e.g. `(...)` subshell grouping, which
+;;fish doesn't understand the same way), use `term-buffer-spawn-with-shell!`
+;;to pin an explicit interpreter instead of gambling on the user's login
+;;shell.
+;;
+;;The buffer closes itself automatically when the child process exits (see
+;;the `document-closed` hook); use `term-buffer-alive?` to check whether
+;;that has already happened.
+;;
+;;```scheme
+;;(term-buffer-spawn! command) -> doc-id?
+;;
+;;command : string?
+;;```
+(define term-buffer-spawn! helix.static.term-buffer-spawn!)
+
+(provide term-buffer-spawn-with-shell!)
+;;@doc
+;;Same as `term-buffer-spawn!`, but running `command` under an explicitly
+;;chosen shell instead of `$SHELL`.
+;;
+;;```scheme
+;;(term-buffer-spawn-with-shell! command shell) -> doc-id?
+;;
+;;command : string?
+;;shell : string?
+;;```
+(define term-buffer-spawn-with-shell! helix.static.term-buffer-spawn-with-shell!)
+
+(provide term-buffer-send!)
+;;@doc
+;;Write raw text to a terminal buffer's child process stdin. No implicit
+;;newline is appended — include `\r` yourself if you want one, same as a
+;;real keypress would send. No-op if `doc-id` isn't a running terminal
+;;buffer (e.g. the process already exited).
+;;
+;;```scheme
+;;(term-buffer-send! doc-id text) -> void?
+;;
+;;doc-id : doc-id?
+;;text : string?
+;;```
+(define term-buffer-send! helix.static.term-buffer-send!)
+
+(provide term-buffer-alive?)
+;;@doc
+;;Whether `doc-id` is a still-running terminal buffer created with
+;;`term-buffer-spawn!`. Becomes `#false` the moment the child process
+;;exits, not just when the buffer is closed some other way — a terminal
+;;buffer always closes itself as soon as this would go false.
+;;
+;;```scheme
+;;(term-buffer-alive? doc-id) -> bool?
+;;
+;;doc-id : doc-id?
+;;```
+(define term-buffer-alive? helix.static.term-buffer-alive?)
+
 (provide enqueue-expression-in-engine)
 ;;@doc
 ;;Enqueue an expression to run at the top level context,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1476,6 +1476,8 @@ fn compute_inlay_hints_for_view(
                     other_inlay_hints,
                     padding_before_inlay_hints,
                     padding_after_inlay_hints,
+                    scoped_inlay_hints: Vec::new(),
+                    scoped_inlay_hint_scopes: Vec::new(),
                 },
             );
             doc.inlay_hints_oudated = false;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -665,7 +665,8 @@ fn terminal_new(
     // Created but not switched to yet: term_pty::PtySession reveals it once
     // the child process has actually produced something to show, instead of
     // flashing an empty buffer during its own shell-fork/exec/init latency.
-    let new_doc = Document::default(cx.editor.config.clone(), cx.editor.syn_loader.clone());
+    let mut new_doc = Document::default(cx.editor.config.clone(), cx.editor.syn_loader.clone());
+    new_doc.is_terminal_buffer = true;
     let doc_id = cx.editor.new_document(new_doc);
     cx.editor.document_mut(doc_id).unwrap().bufferline_name = Some("term".to_string());
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1,6 +1,8 @@
 use std::io::BufReader;
 use std::ops::{self, Deref};
+use std::path::PathBuf;
 
+use crate::events::DocumentWillSave;
 use crate::job::Job;
 
 use super::*;
@@ -383,6 +385,36 @@ fn write_impl(
     path: Option<&str>,
     options: WriteOptions,
 ) -> anyhow::Result<()> {
+    let doc_id = doc!(cx.editor).id();
+    let resolved_path = path
+        .map(PathBuf::from)
+        .or_else(|| doc!(cx.editor).path().map(|p| p.to_path_buf()));
+
+    let mut cancel = false;
+    // `DocumentWillSave` hooks run through the same dispatch machinery as
+    // command hooks (`PostCommand`, etc.), which expects `commands::Context`
+    // rather than the `compositor::Context` typed commands are given. Build a
+    // throwaway one over the same `editor`/`jobs` borrows; any compositor
+    // callback a hook queues (e.g. pushing a popup) is dropped, since there's
+    // nowhere to hand it off to here.
+    let mut command_cx = Context {
+        register: None,
+        count: None,
+        editor: cx.editor,
+        callback: Vec::new(),
+        on_next_key_callback: None,
+        jobs: cx.jobs,
+    };
+    helix_event::dispatch(DocumentWillSave {
+        doc: doc_id,
+        path: resolved_path.as_deref(),
+        cancel: &mut cancel,
+        cx: &mut command_cx,
+    });
+    if cancel {
+        return Ok(());
+    }
+
     let config = cx.editor.config();
     let (view, doc) = current!(cx.editor);
     let doc_id = doc.id();

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -645,6 +645,35 @@ fn new_file(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> an
     Ok(())
 }
 
+fn terminal_new(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    cx.editor.new_file(Action::Replace);
+
+    let (view, doc) = current!(cx.editor);
+    let doc_id = doc.id();
+    let view_id = view.id;
+    let area = view.inner_area(doc);
+    // Reserve one column: a pty line that exactly fills `cols` (common for
+    // box-drawn full-width TUI panels) sits right on Helix's own soft-wrap
+    // boundary and gets wrapped a second time on top of vt100's grid.
+    let (rows, cols) = (area.height.max(1), area.width.saturating_sub(1).max(1));
+
+    doc.bufferline_name = Some("term".to_string());
+
+    crate::term_pty::PtySession::spawn(doc_id, view_id, rows, cols, None, None)?;
+
+    cx.editor.mode = Mode::Insert;
+
+    Ok(())
+}
+
 fn format(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -3230,6 +3259,17 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &["n"],
         doc: "Create a new scratch buffer.",
         fun: new_file,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "term-buffer",
+        aliases: &["termbuf"],
+        doc: "Open a terminal buffer running your shell in the current split.",
+        fun: terminal_new,
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, Some(0)),

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -654,10 +654,7 @@ fn terminal_new(
         return Ok(());
     }
 
-    cx.editor.new_file(Action::Replace);
-
     let (view, doc) = current!(cx.editor);
-    let doc_id = doc.id();
     let view_id = view.id;
     let area = view.inner_area(doc);
     // Reserve one column: a pty line that exactly fills `cols` (common for
@@ -665,11 +662,14 @@ fn terminal_new(
     // boundary and gets wrapped a second time on top of vt100's grid.
     let (rows, cols) = (area.height.max(1), area.width.saturating_sub(1).max(1));
 
-    doc.bufferline_name = Some("term".to_string());
+    // Created but not switched to yet: term_pty::PtySession reveals it once
+    // the child process has actually produced something to show, instead of
+    // flashing an empty buffer during its own shell-fork/exec/init latency.
+    let new_doc = Document::default(cx.editor.config.clone(), cx.editor.syn_loader.clone());
+    let doc_id = cx.editor.new_document(new_doc);
+    cx.editor.document_mut(doc_id).unwrap().bufferline_name = Some("term".to_string());
 
     crate::term_pty::PtySession::spawn(doc_id, view_id, rows, cols, None, None)?;
-
-    cx.editor.mode = Mode::Insert;
 
     Ok(())
 }

--- a/helix-term/src/events.rs
+++ b/helix-term/src/events.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use helix_event::{events, register_event};
 use helix_view::document::Mode;
 use helix_view::events::{
@@ -5,6 +7,7 @@ use helix_view::events::{
     DocumentFocusLost, DocumentSaved, LanguageServerExited, LanguageServerInitialized,
     LspProgressUpdate, SelectionDidChange,
 };
+use helix_view::DocumentId;
 
 use crate::commands;
 use crate::keymap::MappableCommand;
@@ -15,6 +18,16 @@ events! {
     PostCommand<'a, 'cx> { command: & 'a MappableCommand, cx: &'a mut commands::Context<'cx> }
     TerminalFocusGained<'a, 'cx> { cx: &'a mut commands::Context<'cx> }
     TerminalFocusLost<'a, 'cx> { cx: &'a mut commands::Context<'cx> }
+    // Fired synchronously before a `:w`-family command writes a document to disk.
+    // A hook can set `*cancel = true` to take over the save entirely (e.g. a
+    // plugin-owned buffer that applies its own side effect instead of a literal
+    // file write) and skip the built-in write path for this invocation.
+    DocumentWillSave<'a, 'cx> {
+        doc: DocumentId,
+        path: Option<&'a Path>,
+        cancel: &'a mut bool,
+        cx: &'a mut commands::Context<'cx>
+    }
 }
 
 pub fn register() {
@@ -23,6 +36,7 @@ pub fn register() {
     register_event::<PostCommand>();
     register_event::<TerminalFocusGained>();
     register_event::<TerminalFocusLost>();
+    register_event::<DocumentWillSave>();
     register_event::<DocumentDidOpen>();
     register_event::<DocumentDidChange>();
     register_event::<DocumentDidClose>();

--- a/helix-term/src/events.rs
+++ b/helix-term/src/events.rs
@@ -3,7 +3,7 @@ use helix_view::document::Mode;
 use helix_view::events::{
     ConfigDidChange, DiagnosticsDidChange, DocumentDidChange, DocumentDidClose, DocumentDidOpen,
     DocumentFocusLost, DocumentSaved, LanguageServerExited, LanguageServerInitialized,
-    SelectionDidChange,
+    LspProgressUpdate, SelectionDidChange,
 };
 
 use crate::commands;
@@ -32,5 +32,6 @@ pub fn register() {
     register_event::<DiagnosticsDidChange>();
     register_event::<LanguageServerInitialized>();
     register_event::<LanguageServerExited>();
+    register_event::<LspProgressUpdate>();
     register_event::<ConfigDidChange>();
 }

--- a/helix-term/src/events.rs
+++ b/helix-term/src/events.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use helix_event::{events, register_event};
+use helix_event::{events, register_event, register_hook};
 use helix_view::document::Mode;
 use helix_view::events::{
     ConfigDidChange, DiagnosticsDidChange, DocumentDidChange, DocumentDidClose, DocumentDidOpen,
@@ -11,6 +11,7 @@ use helix_view::DocumentId;
 
 use crate::commands;
 use crate::keymap::MappableCommand;
+use crate::term_pty;
 
 events! {
     OnModeSwitch<'a, 'cx> { old_mode: Mode, new_mode: Mode, cx: &'a mut commands::Context<'cx> }
@@ -48,4 +49,9 @@ pub fn register() {
     register_event::<LanguageServerExited>();
     register_event::<LspProgressUpdate>();
     register_event::<ConfigDidChange>();
+
+    register_hook!(move |event: &mut DocumentDidClose<'_>| {
+        term_pty::cleanup(event.doc.id());
+        Ok(())
+    });
 }

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -2,6 +2,7 @@ pub mod default;
 pub mod macros;
 
 pub use crate::commands::MappableCommand;
+use crate::commands::engine::ScriptingEngine;
 pub use default::default;
 
 use arc_swap::{
@@ -55,17 +56,33 @@ impl KeyTrieNode {
     }
 
     pub fn infobox(&self) -> Info {
-        let mut body: Vec<(BTreeSet<KeyEvent>, &str)> = Vec::with_capacity(self.len());
+        let mut body: Vec<(BTreeSet<KeyEvent>, Cow<str>)> = Vec::with_capacity(self.len());
         for (&key, trie) in self.iter() {
-            let desc = match trie {
+            let desc: Cow<str> = match trie {
                 KeyTrie::MappableCommand(cmd) => {
                     if cmd.name() == "no_op" {
                         continue;
                     }
-                    cmd.doc()
+                    match cmd {
+                        // Typable commands backed by a steel plugin fall back to a
+                        // generic "Undocumented plugin command" doc (set at parse
+                        // time, before the engine has loaded any `;;@doc` comments).
+                        // Resolve the real doc lazily here instead, since by the
+                        // time a keymap infobox is shown the engine is up.
+                        MappableCommand::Typable { .. } => {
+                            ScriptingEngine::get_doc_for_identifier(cmd.name())
+                                .and_then(|doc| {
+                                    let first_line = doc.lines().next().unwrap_or_default();
+                                    (!first_line.is_empty())
+                                        .then(|| Cow::Owned(first_line.to_string()))
+                                })
+                                .unwrap_or_else(|| Cow::Borrowed(cmd.doc()))
+                        }
+                        _ => Cow::Borrowed(cmd.doc()),
+                    }
                 }
-                KeyTrie::Node(n) => &n.name,
-                KeyTrie::Sequence(_) => "[Multiple commands]",
+                KeyTrie::Node(n) => Cow::Borrowed(n.name.as_str()),
+                KeyTrie::Sequence(_) => Cow::Borrowed("[Multiple commands]"),
             };
             match body.iter().position(|(_, d)| d == &desc) {
                 Some(pos) => {

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -11,6 +11,7 @@ pub mod health;
 pub mod job;
 pub mod keymap;
 pub mod logging;
+pub mod term_pty;
 pub mod ui;
 
 #[cfg(not(windows))]

--- a/helix-term/src/term_pty.rs
+++ b/helix-term/src/term_pty.rs
@@ -21,6 +21,7 @@ use parking_lot::Mutex;
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 
 use helix_view::document::Mode;
+use helix_view::editor::Action;
 use helix_view::input::{KeyCode, KeyEvent, KeyModifiers};
 use helix_view::{DocumentId, ViewId};
 
@@ -51,6 +52,25 @@ pub struct PtySession {
     /// Last plain character written (outside of any escape sequence), for
     /// expanding ECMA-48 REP (see `preprocess`).
     last_char: Mutex<Option<char>>,
+    /// Whether the buffer has been switched to/shown yet. `doc_id` is
+    /// created but deliberately not displayed anywhere at spawn time —
+    /// `refresh_document` reveals it the first time there's real content to
+    /// show, so the child process's own startup latency (shell fork/exec,
+    /// its own init) never flashes an empty buffer first.
+    revealed: AtomicBool,
+}
+
+/// Whether terminal buffers hide the line-number gutter (default: yes — a
+/// full-width blank/loading terminal reads as "a terminal", whereas one
+/// with Helix's usual gutter furniture reads as "an empty file").
+static HIDE_GUTTER: AtomicBool = AtomicBool::new(true);
+
+pub fn hide_gutter() -> bool {
+    HIDE_GUTTER.load(Ordering::Relaxed)
+}
+
+pub fn set_hide_gutter(hide: bool) {
+    HIDE_GUTTER.store(hide, Ordering::Relaxed);
 }
 
 /// Minimal `vte::Perform` that only cares about the handful of CSI queries
@@ -193,6 +213,7 @@ impl PtySession {
             query_detector: Mutex::new((vte::Parser::new(), QueryResponder::default())),
             dirty: AtomicBool::new(false),
             last_char: Mutex::new(None),
+            revealed: AtomicBool::new(false),
         });
 
         TERMINALS.lock().insert(doc_id, session.clone());
@@ -355,9 +376,33 @@ impl PtySession {
 
     fn refresh_document(&self) {
         let doc_id = self.doc_id;
-        let view_id = self.view_id;
+        let spawn_view_id = self.view_id;
         let parser = self.parser.clone();
+        // Computed on whichever thread calls refresh_document (read_loop or
+        // the ticker) — the atomic swap means only the first caller, ever,
+        // sees `true`, so exactly one queued callback ends up doing the
+        // reveal, however many refreshes happen to race into the queue
+        // around the same time.
+        let just_revealed = !self.revealed.swap(true, Ordering::AcqRel);
         job::dispatch_blocking(move |editor, _compositor| {
+            if !editor.documents.contains_key(&doc_id) {
+                return;
+            }
+            let view_id = if just_revealed {
+                // First real content: switch to the buffer now instead of
+                // at spawn time, so the child process's own startup latency
+                // (shell fork/exec, its own init) never flashes an empty
+                // buffer before there's something to show.
+                editor.switch(doc_id, Action::Replace);
+                editor.mode = Mode::Insert;
+                // `switch` reveals into whichever view is *currently*
+                // focused, which may not be `spawn_view_id` if the user
+                // moved on before the child's first output arrived — use
+                // the view it actually landed in for the cursor sync below.
+                editor.tree.focus
+            } else {
+                spawn_view_id
+            };
             let Some(doc) = editor.document_mut(doc_id) else {
                 return;
             };

--- a/helix-term/src/term_pty.rs
+++ b/helix-term/src/term_pty.rs
@@ -20,6 +20,7 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 
+use helix_view::document::Mode;
 use helix_view::input::{KeyCode, KeyEvent, KeyModifiers};
 use helix_view::{DocumentId, ViewId};
 
@@ -336,8 +337,19 @@ impl PtySession {
         // buffer showing a dead shell isn't useful to leave open.
         let _ = self.child.lock().wait();
         let doc_id = self.doc_id;
+        let view_id = self.view_id;
         job::dispatch_blocking(move |editor, _compositor| {
+            // Only if the terminal's own view still has focus and is still
+            // showing it — otherwise the user has since moved on to editing
+            // something else, and forcing Normal mode there would yank them
+            // out of unrelated typing just because a background process
+            // happened to exit at that moment.
+            let was_focused = editor.tree.focus == view_id
+                && editor.tree.try_get(view_id).map(|v| v.doc) == Some(doc_id);
             let _ = editor.close_document(doc_id, true);
+            if was_focused {
+                editor.mode = Mode::Normal;
+            }
         });
     }
 

--- a/helix-term/src/term_pty.rs
+++ b/helix-term/src/term_pty.rs
@@ -1,0 +1,624 @@
+//! PTY-backed terminal buffers.
+//!
+//! A terminal buffer is a normal `Document`/`View` like any other: its rope
+//! is kept in sync with a child process's PTY output instead of a file. This
+//! module owns the PTY/child process and the `vt100` screen state; it never
+//! touches the compositor, so a terminal buffer gets bufferline, splits, and
+//! buffer-next/previous for free from the existing document machinery.
+//!
+//! Sessions are tracked in a global registry keyed by `DocumentId` (the same
+//! pattern `job::JOB_QUEUE` uses for the job-dispatch channel) rather than
+//! threaded through `Application`, since the PTY needs to be reachable from
+//! both command handlers and the key-routing code in `ui/editor.rs`.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
+
+use helix_view::input::{KeyCode, KeyEvent, KeyModifiers};
+use helix_view::{DocumentId, ViewId};
+
+use crate::job;
+
+/// Scrollback kept by the vt100 parser, in lines, beyond the visible screen.
+const SCROLLBACK_LINES: usize = 10_000;
+
+pub struct PtySession {
+    doc_id: DocumentId,
+    view_id: ViewId,
+    master: Mutex<Box<dyn MasterPty + Send>>,
+    writer: Mutex<Box<dyn Write + Send>>,
+    child: Mutex<Box<dyn Child + Send + Sync>>,
+    parser: Arc<Mutex<vt100::Parser>>,
+    /// Detects terminal capability queries (DA/DSR) that `vt100` silently
+    /// drops, so we can answer them instead of the child program hanging.
+    query_detector: Mutex<(vte::Parser, QueryResponder)>,
+    /// Set whenever the parser processes new bytes, cleared by the ticker
+    /// thread once it flushes to the document. A fixed-cadence ticker (not
+    /// "refresh after each read") is what actually guarantees delivery: a
+    /// refresh keyed off read arrivals can throttle away the *last* chunk of
+    /// a burst with nothing left to trigger the deferred flush once the
+    /// child goes quiet (e.g. a shell that draws its prompt right after
+    /// startup output, then just waits for input) — the prompt would then
+    /// only show up once some *later* read happened to come in.
+    dirty: AtomicBool,
+    /// Last plain character written (outside of any escape sequence), for
+    /// expanding ECMA-48 REP (see `preprocess`).
+    last_char: Mutex<Option<char>>,
+}
+
+/// Minimal `vte::Perform` that only cares about the handful of CSI queries
+/// an interactive shell is likely to issue at startup, run over the same raw
+/// bytes fed to the main `vt100::Parser`. Everything else is a no-op via the
+/// trait's defaults.
+#[derive(Default)]
+struct QueryResponder {
+    cursor_row: u16,
+    cursor_col: u16,
+    responses: Vec<u8>,
+}
+
+impl vte::Perform for QueryResponder {
+    fn csi_dispatch(&mut self, params: &vte::Params, intermediates: &[u8], _ignore: bool, c: char) {
+        match (intermediates.first(), c) {
+            // Primary Device Attributes: "what kind of terminal are you?"
+            // fish (among others) blocks for ~10s waiting on this before
+            // giving up and disabling the features that depend on it.
+            (None, 'c') => self.responses.extend_from_slice(b"\x1b[?6c"),
+            // Device Status Report.
+            (None, 'n') => {
+                let code = params
+                    .iter()
+                    .next()
+                    .and_then(|p| p.first())
+                    .copied()
+                    .unwrap_or(0);
+                match code {
+                    5 => self.responses.extend_from_slice(b"\x1b[0n"),
+                    6 => {
+                        let report =
+                            format!("\x1b[{};{}R", self.cursor_row + 1, self.cursor_col + 1);
+                        self.responses.extend_from_slice(report.as_bytes());
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+static TERMINALS: Lazy<Mutex<HashMap<DocumentId, Arc<PtySession>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Look up the live PTY session backing a terminal buffer, if `doc_id` is one.
+pub fn get(doc_id: DocumentId) -> Option<Arc<PtySession>> {
+    TERMINALS.lock().get(&doc_id).cloned()
+}
+
+pub fn is_terminal(doc_id: DocumentId) -> bool {
+    TERMINALS.lock().contains_key(&doc_id)
+}
+
+/// Kill the child process and drop the PTY for a closed terminal buffer.
+/// Wired to the `DocumentDidClose` event in `events.rs` so it fires
+/// regardless of which command path closed the buffer.
+pub fn cleanup(doc_id: DocumentId) {
+    if let Some(session) = TERMINALS.lock().remove(&doc_id) {
+        let _ = session.child.lock().kill();
+    }
+}
+
+impl PtySession {
+    /// Spawn a PTY sized `rows`x`cols` and register it as the terminal
+    /// session backing `doc_id` (displayed in `view_id`). A background
+    /// thread feeds PTY output into a vt100 screen and re-flattens it into
+    /// the document's rope on every read.
+    ///
+    /// `command`, if given, is run as `shell -c command` instead of an
+    /// interactive shell — this is how plugins (lazygit.hx, sidekick.hx,
+    /// ...) embed a specific program (`exec lazygit`, an AI CLI, ...) as a
+    /// terminal buffer via `term-buffer-spawn!` rather than opening a shell
+    /// the user has to type a command into themselves. `shell` defaults to
+    /// `$SHELL` when not given; plugins whose command uses syntax that
+    /// isn't portable across shells (e.g. POSIX `(...)` subshell grouping,
+    /// which fish doesn't understand the same way) can pin one explicitly
+    /// via `term-buffer-spawn-with-shell!` instead of guessing what the
+    /// user's login shell is.
+    pub fn spawn(
+        doc_id: DocumentId,
+        view_id: ViewId,
+        rows: u16,
+        cols: u16,
+        command: Option<&str>,
+        shell: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let pty_system = native_pty_system();
+        let pair = pty_system.openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+
+        let mut cmd = match command {
+            // `new_default_prog` builds a special marker that resolves the
+            // shell at spawn time and explicitly forbids `.arg()` (panics
+            // if called) — fine for a bare interactive shell, but a custom
+            // command needs `shell -c command`, so resolve the shell path
+            // ourselves the same way `new_default_prog` would.
+            Some(command) => {
+                let shell = shell.map(str::to_string).unwrap_or_else(|| {
+                    std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
+                });
+                let mut cmd = CommandBuilder::new(shell);
+                cmd.arg("-c");
+                cmd.arg(command);
+                cmd
+            }
+            None => CommandBuilder::new_default_prog(),
+        };
+        // `vt100` only understands a basic xterm-ish subset. Inheriting
+        // hx's own $TERM (e.g. tmux-256color, or whatever the host terminal
+        // reports) advertises features vt100 can't parse, which is enough
+        // to garble full-screen apps like vim; pin the child to a baseline
+        // vt100 is actually able to keep up with.
+        cmd.env("TERM", "xterm-256color");
+        cmd.cwd(helix_stdx::env::current_working_dir());
+        let child = pair.slave.spawn_command(cmd)?;
+        // Our handle to the slave side only needs to live long enough to hand
+        // it to the child; the child's own copy (stdin/stdout/stderr) is what
+        // keeps the pty alive, and dropping ours here lets the master side see
+        // EOF when the child actually exits instead of when we happen to.
+        drop(pair.slave);
+
+        let reader = pair.master.try_clone_reader()?;
+        let writer = pair.master.take_writer()?;
+
+        let parser = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, SCROLLBACK_LINES)));
+
+        let session = Arc::new(Self {
+            doc_id,
+            view_id,
+            master: Mutex::new(pair.master),
+            writer: Mutex::new(writer),
+            child: Mutex::new(child),
+            parser,
+            query_detector: Mutex::new((vte::Parser::new(), QueryResponder::default())),
+            dirty: AtomicBool::new(false),
+            last_char: Mutex::new(None),
+        });
+
+        TERMINALS.lock().insert(doc_id, session.clone());
+
+        std::thread::Builder::new()
+            .name("term-pty-reader".to_string())
+            .spawn({
+                let session = session.clone();
+                move || session.read_loop(reader)
+            })?;
+
+        // Flushes to the document on a fixed cadence rather than "after each
+        // read": decoupling from read timing is what guarantees delivery
+        // (see the `dirty` field doc comment). Exits on its own once the
+        // session is dropped (weak ref fails to upgrade), so it doesn't need
+        // to be told about the child exiting or the buffer closing.
+        let ticker_session = Arc::downgrade(&session);
+        std::thread::Builder::new()
+            .name("term-pty-ticker".to_string())
+            .spawn(move || loop {
+                std::thread::sleep(std::time::Duration::from_millis(16));
+                let Some(session) = ticker_session.upgrade() else {
+                    break;
+                };
+                if session.dirty.swap(false, Ordering::AcqRel) {
+                    session.refresh_document();
+                }
+            })?;
+
+        Ok(())
+    }
+
+    /// Patch up CSI sequences `vt100` handles incorrectly or not at all,
+    /// before handing bytes to it. Operates on raw bytes (walking the
+    /// ECMA-48 CSI grammar directly: `ESC [ params intermediates final`)
+    /// rather than going through a `vte::Parser` + `Perform` pass, so that
+    /// every sequence this doesn't specifically special-case can be copied
+    /// through byte-for-byte — no risk of subtly mis-reconstructing a
+    /// sequence from parsed params/intermediates.
+    ///
+    /// Two rewrites, both found by diffing btop's raw output against
+    /// `vt100`'s CSI dispatch table (`vt100-0.15.2/src/screen.rs`):
+    ///
+    /// - `CSI Pb` (REP, "repeat the preceding character P times") has no
+    ///   handler in `vt100` at all, so it's expanded here into literal
+    ///   repeated characters.
+    /// - `CSI row;col f` (HVP) is functionally identical to `CSI row;col H`
+    ///   (CUP), but `vt100` only implements `H`; every `f` cursor move was
+    ///   silently dropped, desyncing the cursor from where btop thought it
+    ///   had positioned it and scrambling everything drawn after. This was
+    ///   the dominant cause of btop looking scrambled (648 `f` sequences in
+    ///   one capture vs. zero `b`/REP sequences) — rewritten to `H` here.
+    fn preprocess(&self, bytes: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(bytes.len());
+        let mut last_char = self.last_char.lock();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == 0x1b && bytes.get(i + 1) == Some(&b'[') {
+                let seq_start = i;
+                let mut j = i + 2;
+                // Parameter bytes: 0x30-0x3F (digits, `;`, `:`, and the
+                // private-marker prefixes `< = > ?`).
+                let param_start = j;
+                while j < bytes.len() && (0x30..=0x3f).contains(&bytes[j]) {
+                    j += 1;
+                }
+                let param_end = j;
+                // Intermediate bytes: 0x20-0x2F.
+                while j < bytes.len() && (0x20..=0x2f).contains(&bytes[j]) {
+                    j += 1;
+                }
+                if j < bytes.len() && (0x40..=0x7e).contains(&bytes[j]) {
+                    let final_byte = bytes[j];
+                    match final_byte {
+                        b'b' => {
+                            let count: usize = std::str::from_utf8(&bytes[param_start..param_end])
+                                .ok()
+                                .and_then(|s| s.parse().ok())
+                                .unwrap_or(1)
+                                .max(1);
+                            if let Some(c) = *last_char {
+                                let mut char_buf = [0u8; 4];
+                                let encoded = c.encode_utf8(&mut char_buf);
+                                for _ in 0..count {
+                                    out.extend_from_slice(encoded.as_bytes());
+                                }
+                            }
+                        }
+                        b'f' => {
+                            out.extend_from_slice(&bytes[seq_start..j]);
+                            out.push(b'H');
+                        }
+                        _ => out.extend_from_slice(&bytes[seq_start..=j]),
+                    }
+                    i = j + 1;
+                    continue;
+                }
+                // Sequence truncated at the end of this chunk (a CSI split
+                // across two reads, which is rare). Not worth reassembling
+                // across reads for a cosmetic-only edge case: fall through
+                // and copy the ESC byte verbatim; the rest resumes as plain
+                // bytes on the next read.
+            }
+            let b = bytes[i];
+            if b < 0x20 || b == 0x7f {
+                // Control byte: passed through, doesn't count as "printed".
+                out.push(b);
+                i += 1;
+                continue;
+            }
+            let char_len = utf8_len(b);
+            let end = (i + char_len).min(bytes.len());
+            if let Ok(s) = std::str::from_utf8(&bytes[i..end]) {
+                if let Some(c) = s.chars().next() {
+                    *last_char = Some(c);
+                }
+            }
+            out.extend_from_slice(&bytes[i..end]);
+            i = end;
+        }
+        out
+    }
+
+    fn read_loop(self: Arc<Self>, mut reader: Box<dyn Read + Send>) {
+        let mut buf = [0u8; 8192];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let expanded = self.preprocess(&buf[..n]);
+                    self.parser.lock().process(&expanded);
+                    self.respond_to_queries(&expanded);
+                    self.dirty.store(true, Ordering::Release);
+                }
+            }
+        }
+        // Flush the final screen state (e.g. an "exited" message) even
+        // though the ticker will also pick this up on its next tick.
+        self.refresh_document();
+        // Reap the child so it doesn't sit around as a zombie now that the
+        // pty has seen EOF, and close the buffer to match: a terminal
+        // buffer showing a dead shell isn't useful to leave open.
+        let _ = self.child.lock().wait();
+        let doc_id = self.doc_id;
+        job::dispatch_blocking(move |editor, _compositor| {
+            let _ = editor.close_document(doc_id, true);
+        });
+    }
+
+    fn refresh_document(&self) {
+        let doc_id = self.doc_id;
+        let view_id = self.view_id;
+        let parser = self.parser.clone();
+        job::dispatch_blocking(move |editor, _compositor| {
+            let Some(doc) = editor.document_mut(doc_id) else {
+                return;
+            };
+            let (text, cursor_row, cursor_col) = {
+                let parser = parser.lock();
+                let screen = parser.screen();
+                // `Screen::contents()` omits the newline between rows the
+                // terminal auto-wrapped into each other, merging them into
+                // one oversized logical line — which breaks the "rope line
+                // N is vt100 row N" invariant `cell_style` depends on, and
+                // then needs re-wrapping by Helix's own renderer on top of
+                // vt100's original wrap. `rows()` keeps every row separate
+                // regardless of wrap state, matching the fixed grid a real
+                // terminal always shows.
+                let cols = screen.size().1;
+                let (cursor_row, cursor_col) = screen.cursor_position();
+                // Curses-style apps (vim, htop, ...) often clear/redraw a
+                // row by writing literal spaces across it rather than an
+                // erase-to-end-of-line sequence, which (unlike a genuinely
+                // untouched cell) counts as real row content. Left in, every
+                // such row would sit exactly at (or a hair past) the view's
+                // width and get soft-wrapped by Helix on top of vt100's own
+                // grid — trailing whitespace is invisible either way, so
+                // trimming it here is a no-op for what's actually on screen.
+                //
+                // Exception: the cursor's own row. The cursor position sync
+                // below needs an actual character at `cursor_col` to place
+                // the selection on — trimming a blank/short row out from
+                // under it would clamp the cursor short and it'd appear one
+                // cell left of where the terminal really has it, snapping
+                // to the right place only once real text pushed the trim
+                // point out that far. Pad that one row back out instead.
+                let text = screen
+                    .rows(0, cols)
+                    .enumerate()
+                    .map(|(i, row)| {
+                        let trimmed = row.trim_end();
+                        if i as u16 == cursor_row && trimmed.chars().count() < cursor_col as usize {
+                            let pad = cursor_col as usize - trimmed.chars().count();
+                            format!("{trimmed}{}", " ".repeat(pad))
+                        } else {
+                            trimmed.to_string()
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                (text, cursor_row, cursor_col)
+            };
+            let new_text = helix_core::Rope::from(text.as_str());
+            let transaction = helix_core::diff::compare_ropes(doc.text(), &new_text);
+            doc.apply(&transaction, view_id);
+
+            // Helix draws its (block) cursor by highlighting whatever the
+            // document's selection currently points at, not via the real
+            // terminal cursor — so without this, the terminal buffer's
+            // cursor just sits wherever the selection was left (buffer
+            // creation, typically) instead of following the shell prompt
+            // or program cursor around like a real terminal would.
+            let text = doc.text();
+            let len_lines = text.len_lines();
+            let row = (cursor_row as usize).min(len_lines.saturating_sub(1));
+            let line_start = text.line_to_char(row);
+            let line_end = if row + 1 < len_lines {
+                text.line_to_char(row + 1).saturating_sub(1)
+            } else {
+                text.len_chars()
+            };
+            let offset = (line_start + cursor_col as usize).min(line_end);
+            doc.set_selection(view_id, helix_core::Selection::point(offset));
+        });
+    }
+
+    /// Scan `bytes` for terminal capability queries (DA/DSR) and write back
+    /// whatever response(s) they call for, using the cursor position `vt100`
+    /// just computed for this same chunk.
+    fn respond_to_queries(&self, bytes: &[u8]) {
+        let (row, col) = self.parser.lock().screen().cursor_position();
+
+        let responses = {
+            let mut guard = self.query_detector.lock();
+            let (parser, responder) = &mut *guard;
+            responder.cursor_row = row;
+            responder.cursor_col = col;
+            for &byte in bytes {
+                parser.advance(responder, byte);
+            }
+            std::mem::take(&mut responder.responses)
+        };
+
+        if !responses.is_empty() {
+            self.write_input(&responses);
+        }
+    }
+
+    /// Whether the child program has put the terminal in application-cursor
+    /// mode (DECCKM) — determines which escape prefix arrow/Home/End keys use.
+    pub fn application_cursor(&self) -> bool {
+        self.parser.lock().screen().application_cursor()
+    }
+
+    /// The style a real terminal would render cell `(row, col)` with (SGR
+    /// colors + bold/italic/underline/inverse), or `None` for a cell with no
+    /// non-default attributes (nothing to override the document's plain text
+    /// style with).
+    pub fn cell_style(&self, row: u16, col: u16) -> Option<helix_view::graphics::Style> {
+        use helix_view::graphics::{Color, Modifier, Style, UnderlineStyle};
+
+        let parser = self.parser.lock();
+        let cell = parser.screen().cell(row, col)?;
+
+        let to_color = |c: vt100::Color| match c {
+            vt100::Color::Default => None,
+            vt100::Color::Idx(i) => Some(Color::Indexed(i)),
+            vt100::Color::Rgb(r, g, b) => Some(Color::Rgb(r, g, b)),
+        };
+
+        let mut fg = to_color(cell.fgcolor());
+        let mut bg = to_color(cell.bgcolor());
+        if cell.inverse() {
+            std::mem::swap(&mut fg, &mut bg);
+        }
+        if fg.is_none() && bg.is_none() && !cell.bold() && !cell.italic() && !cell.underline() {
+            return None;
+        }
+
+        let mut style = Style {
+            fg,
+            bg,
+            ..Style::default()
+        };
+        if cell.bold() {
+            style = style.add_modifier(Modifier::BOLD);
+        }
+        if cell.italic() {
+            style = style.add_modifier(Modifier::ITALIC);
+        }
+        if cell.underline() {
+            style.underline_style = Some(UnderlineStyle::Line);
+        }
+        Some(style)
+    }
+
+    /// Forward raw bytes to the child process's stdin.
+    pub fn write_input(&self, bytes: &[u8]) {
+        let mut writer = self.writer.lock();
+        let _ = writer.write_all(bytes);
+        let _ = writer.flush();
+    }
+
+    /// Resize the pty (and the vt100 screen tracking it) to match the view.
+    /// Called on every render of a terminal buffer's view, so it no-ops
+    /// unless the size actually changed.
+    pub fn resize(&self, rows: u16, cols: u16) {
+        if rows == 0 || cols == 0 {
+            return;
+        }
+        {
+            let mut parser = self.parser.lock();
+            if parser.screen().size() == (rows, cols) {
+                return;
+            }
+            parser.set_size(rows, cols);
+        }
+        let _ = self.master.lock().resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        });
+        self.refresh_document();
+    }
+}
+
+/// Encode a key event into the byte sequence a real terminal would send for
+/// it, or `None` for keys with no terminal representation (e.g. plain
+/// modifier keys). `application_cursor` selects the SS3 (`ESC O`) vs. CSI
+/// (`ESC [`) prefix for arrow/Home/End, matching whatever the running
+/// program (e.g. vim) last requested via DECCKM.
+pub fn encode_key(key: &KeyEvent, application_cursor: bool) -> Option<Vec<u8>> {
+    let KeyEvent { code, modifiers } = *key;
+    let alt = modifiers.contains(KeyModifiers::ALT);
+
+    let mut bytes = match code {
+        KeyCode::Char(c) if modifiers.contains(KeyModifiers::CONTROL) => encode_ctrl_char(c)?,
+        KeyCode::Char(c) => {
+            let mut buf = [0u8; 4];
+            c.encode_utf8(&mut buf).as_bytes().to_vec()
+        }
+        KeyCode::Enter => vec![b'\r'],
+        KeyCode::Backspace => vec![0x7f],
+        KeyCode::Tab => vec![b'\t'],
+        KeyCode::Esc => vec![0x1b],
+        KeyCode::Delete => csi_seq(b"3~"),
+        KeyCode::Insert => csi_seq(b"2~"),
+        KeyCode::PageUp => csi_seq(b"5~"),
+        KeyCode::PageDown => csi_seq(b"6~"),
+        KeyCode::Home => cursor_seq(b'H', application_cursor),
+        KeyCode::End => cursor_seq(b'F', application_cursor),
+        KeyCode::Up => cursor_seq(b'A', application_cursor),
+        KeyCode::Down => cursor_seq(b'B', application_cursor),
+        KeyCode::Right => cursor_seq(b'C', application_cursor),
+        KeyCode::Left => cursor_seq(b'D', application_cursor),
+        KeyCode::F(n) => function_key_seq(n),
+        _ => return None,
+    };
+
+    if alt {
+        bytes.insert(0, 0x1b);
+    }
+    Some(bytes)
+}
+
+fn encode_ctrl_char(c: char) -> Option<Vec<u8>> {
+    let upper = c.to_ascii_uppercase();
+    let byte = if upper.is_ascii_alphabetic() {
+        (upper as u8) & 0x1f
+    } else {
+        match c {
+            '@' | ' ' => 0,
+            '[' => 0x1b,
+            '\\' => 0x1c,
+            ']' => 0x1d,
+            '^' => 0x1e,
+            '_' | '?' => 0x1f,
+            _ => return None,
+        }
+    };
+    Some(vec![byte])
+}
+
+fn cursor_seq(final_byte: u8, application_cursor: bool) -> Vec<u8> {
+    vec![
+        0x1b,
+        if application_cursor { b'O' } else { b'[' },
+        final_byte,
+    ]
+}
+
+fn csi_seq(seq: &[u8]) -> Vec<u8> {
+    let mut out = vec![0x1b, b'['];
+    out.extend_from_slice(seq);
+    out
+}
+
+/// Byte length of the UTF-8 character starting with leading byte `b`.
+fn utf8_len(b: u8) -> usize {
+    if b & 0x80 == 0 {
+        1
+    } else if b & 0xe0 == 0xc0 {
+        2
+    } else if b & 0xf0 == 0xe0 {
+        3
+    } else if b & 0xf8 == 0xf0 {
+        4
+    } else {
+        1
+    }
+}
+
+fn function_key_seq(n: u8) -> Vec<u8> {
+    match n {
+        1 => b"\x1bOP".to_vec(),
+        2 => b"\x1bOQ".to_vec(),
+        3 => b"\x1bOR".to_vec(),
+        4 => b"\x1bOS".to_vec(),
+        5 => b"\x1b[15~".to_vec(),
+        6 => b"\x1b[17~".to_vec(),
+        7 => b"\x1b[18~".to_vec(),
+        8 => b"\x1b[19~".to_vec(),
+        9 => b"\x1b[20~".to_vec(),
+        10 => b"\x1b[21~".to_vec(),
+        11 => b"\x1b[23~".to_vec(),
+        12 => b"\x1b[24~".to_vec(),
+        _ => Vec::new(),
+    }
+}

--- a/helix-term/src/term_pty.rs
+++ b/helix-term/src/term_pty.rs
@@ -23,7 +23,6 @@ use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize}
 use helix_view::document::Mode;
 use helix_view::editor::Action;
 use helix_view::input::{KeyCode, KeyEvent, KeyModifiers};
-use helix_view::view::ViewPosition;
 use helix_view::{DocumentId, ViewId};
 
 use crate::job;
@@ -404,21 +403,6 @@ impl PtySession {
             } else {
                 spawn_view_id
             };
-            // Every view currently showing this doc, gathered before `doc`
-            // borrows `editor` mutably below — used to re-pin scroll
-            // position after `apply`, since its anchor-remapping (needed so
-            // a saved scroll position tracks surrounding *text* edits)
-            // otherwise drifts a stored offset away from 0 as the screen
-            // gets diffed/replaced wholesale on every frame, including for
-            // views that aren't focused right now. Left uncorrected, that
-            // stale offset is what a view snaps back to when the user
-            // switches back to a terminal buffer that kept redrawing in the
-            // background (e.g. `btop`, `lazygit`) while they were elsewhere.
-            let doc_view_ids: Vec<ViewId> = editor
-                .tree
-                .views()
-                .filter_map(|(view, _)| (view.doc == doc_id).then_some(view.id))
-                .collect();
             let Some(doc) = editor.document_mut(doc_id) else {
                 return;
             };
@@ -470,9 +454,14 @@ impl PtySession {
             let new_text = helix_core::Rope::from(text.as_str());
             let transaction = helix_core::diff::compare_ropes(doc.text(), &new_text);
             doc.apply(&transaction, view_id);
-            for vid in &doc_view_ids {
-                doc.set_view_offset(*vid, ViewPosition::default());
-            }
+            // A terminal buffer is never "saved" in any meaningful sense,
+            // but its content changing every frame would otherwise leave it
+            // permanently `is_modified() == true` (there's nothing else to
+            // commit these changes to history and clear it, since
+            // `append_changes_to_history` is skipped for terminal buffers -
+            // see `ui/editor.rs`) - forcing `:q`/`:qa` to need `!` for a
+            // buffer the user never asked to persist in the first place.
+            doc.discard_pending_changes();
 
             // Helix draws its (block) cursor by highlighting whatever the
             // document's selection currently points at, not via the real

--- a/helix-term/src/term_pty.rs
+++ b/helix-term/src/term_pty.rs
@@ -23,6 +23,7 @@ use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize}
 use helix_view::document::Mode;
 use helix_view::editor::Action;
 use helix_view::input::{KeyCode, KeyEvent, KeyModifiers};
+use helix_view::view::ViewPosition;
 use helix_view::{DocumentId, ViewId};
 
 use crate::job;
@@ -403,6 +404,21 @@ impl PtySession {
             } else {
                 spawn_view_id
             };
+            // Every view currently showing this doc, gathered before `doc`
+            // borrows `editor` mutably below — used to re-pin scroll
+            // position after `apply`, since its anchor-remapping (needed so
+            // a saved scroll position tracks surrounding *text* edits)
+            // otherwise drifts a stored offset away from 0 as the screen
+            // gets diffed/replaced wholesale on every frame, including for
+            // views that aren't focused right now. Left uncorrected, that
+            // stale offset is what a view snaps back to when the user
+            // switches back to a terminal buffer that kept redrawing in the
+            // background (e.g. `btop`, `lazygit`) while they were elsewhere.
+            let doc_view_ids: Vec<ViewId> = editor
+                .tree
+                .views()
+                .filter_map(|(view, _)| (view.doc == doc_id).then_some(view.id))
+                .collect();
             let Some(doc) = editor.document_mut(doc_id) else {
                 return;
             };
@@ -454,6 +470,9 @@ impl PtySession {
             let new_text = helix_core::Rope::from(text.as_str());
             let transaction = helix_core::diff::compare_ropes(doc.text(), &new_text);
             doc.apply(&transaction, view_id);
+            for vid in &doc_view_ids {
+                doc.set_view_offset(*vid, ViewPosition::default());
+            }
 
             // Helix draws its (block) cursor by highlighting whatever the
             // document's selection currently points at, not via the real

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -671,7 +671,7 @@ impl EditorView {
         doc.script_highlights()
             .values()
             .filter_map(|group| {
-                let highlight = theme.find_highlight_exact(&group.scope)?;
+                let highlight = theme.find_highlight(&group.scope)?;
                 Some(OverlayHighlights::Homogeneous {
                     highlight,
                     ranges: group.ranges.clone(),
@@ -1694,11 +1694,12 @@ impl Component for EditorView {
             Self::render_bufferline(cx.editor, area.with_height(1), surface);
         }
 
+        let suppress_cursor = cx.editor.steel_terminal_has_focus;
         let views: Vec<(ViewId, bool)> = {
             cx.editor
                 .tree
                 .views()
-                .map(|(view, is_focused)| (view.id, is_focused))
+                .map(|(view, is_focused)| (view.id, if suppress_cursor { false } else { is_focused }))
                 .collect()
         };
         for (view_id, is_focused) in views {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -714,18 +714,21 @@ impl EditorView {
         let current_doc = view!(editor).doc;
 
         for doc in editor.documents() {
-            let fname = match doc.path() {
-                Some(path) => path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_str()
-                    .unwrap_or_default(),
-                // No real path - prefer a plugin-set short tab label (e.g.
-                // "oil" for a file-manager buffer) over the generic marker.
-                None => doc
-                    .bufferline_name
-                    .as_deref()
-                    .unwrap_or(SCRATCH_BUFFER_NAME),
+            // A plugin-set short tab label (e.g. "oil" for a file-manager
+            // buffer, or "ours"/"theirs" for a merge-conflict side pane)
+            // always wins when set, even over a real path - a plugin asking
+            // for a specific label is intentionally relabeling the tab, not
+            // just filling in a gap left by a pathless scratch buffer.
+            let fname = match doc.bufferline_name.as_deref() {
+                Some(name) => name,
+                None => match doc.path() {
+                    Some(path) => path
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_str()
+                        .unwrap_or_default(),
+                    None => SCRATCH_BUFFER_NAME,
+                },
             };
 
             let style = if current_doc == doc.id() {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -153,6 +153,7 @@ impl EditorView {
             }
 
             Self::doc_diagnostics_highlights_into(doc, theme, &mut overlays);
+            overlays.extend(Self::doc_script_highlights(doc, theme));
 
             if is_focused {
                 if config.lsp.auto_document_highlight {
@@ -664,6 +665,19 @@ impl EditorView {
         let pos = doc.selection(view.id).primary().cursor(text);
         let pos = helix_core::match_brackets::find_matching_bracket(syntax, text, pos)?;
         Some(OverlayHighlights::single(highlight, pos..pos + 1))
+    }
+
+    pub fn doc_script_highlights(doc: &Document, theme: &Theme) -> Vec<OverlayHighlights> {
+        doc.script_highlights()
+            .values()
+            .filter_map(|group| {
+                let highlight = theme.find_highlight_exact(&group.scope)?;
+                Some(OverlayHighlights::Homogeneous {
+                    highlight,
+                    ranges: group.ranges.clone(),
+                })
+            })
+            .collect()
     }
 
     pub fn tabstop_highlights(doc: &Document, theme: &Theme) -> Option<OverlayHighlights> {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -5,6 +5,7 @@ use crate::{
     handlers::completion::CompletionItem,
     key,
     keymap::{KeymapResult, Keymaps},
+    term_pty,
     ui::{
         document::{render_document, LinePos, TextRenderer},
         statusline,
@@ -29,6 +30,7 @@ use helix_view::{
     graphics::{Color, CursorKind, Modifier, Rect, Style},
     input::{KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     keyboard::{KeyCode, KeyModifiers},
+    tree::Direction as SplitDirection,
     Document, DocumentId, Editor, Theme, View, ViewId,
 };
 use std::{mem::take, num::NonZeroUsize, ops, rc::Rc};
@@ -44,6 +46,10 @@ pub struct EditorView {
     spinners: ProgressSpinners,
     /// Tracks if the terminal window is focused by reaction to terminal focus events
     terminal_focused: bool,
+    /// Set after a `<C-\>` while a terminal buffer has input focus: the next
+    /// key decides whether this detaches to Normal mode (`<C-n>`) or was just
+    /// a literal `<C-\>` meant for the child process (anything else).
+    terminal_detach_pending: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -67,6 +73,7 @@ impl EditorView {
             completion: None,
             spinners: ProgressSpinners::default(),
             terminal_focused: true,
+            terminal_detach_pending: false,
         }
     }
 
@@ -89,6 +96,17 @@ impl EditorView {
             let editor = &cx.editor;
 
             let inner = view.inner_area(doc);
+            // Only the focused view drives the pty's size: a terminal buffer
+            // split into two views can't have two sizes, and resizing from
+            // whichever view happened to render last would fight itself.
+            if is_focused {
+                if let Some(session) = term_pty::get(doc_id) {
+                    // See the matching comment in `terminal_new` (typed.rs):
+                    // one column of slack so a full-width pty line doesn't
+                    // sit exactly on Helix's soft-wrap boundary.
+                    session.resize(inner.height, inner.width.saturating_sub(1));
+                }
+            }
             let area = view.area;
             let theme = &editor.theme;
             let config = editor.config();
@@ -171,6 +189,10 @@ impl EditorView {
                     theme,
                     &config.cursor_shape,
                     self.terminal_focused,
+                    // A real terminal's cursor is always a solid block,
+                    // independent of whatever cursor shape the user
+                    // configured for Insert mode generally.
+                    term_pty::is_terminal(doc_id),
                 ));
                 if let Some(overlay) = Self::highlight_focused_view_elements(view, doc, theme) {
                     overlays.push(overlay);
@@ -227,6 +249,29 @@ impl EditorView {
                 theme,
                 decorations,
             );
+
+            // Recolor terminal buffer cells to match the child program's SGR
+            // output (colors, bold/italic/underline). This has to run *after*
+            // `render_document` rather than through a `Decoration`: normal
+            // text drawing always sets an explicit foreground color, which
+            // would stomp a foreground color set beforehand via a decoration
+            // (background/modifiers survive that since they're usually left
+            // unset, which is what made this easy to miss before checking).
+            if let Some(session) = term_pty::get(doc_id) {
+                let text = doc.text().slice(..);
+                let first_line = text.char_to_line(view_offset.anchor.min(text.len_chars()));
+                for y in 0..inner.height {
+                    let doc_line = first_line + y as usize;
+                    if doc_line >= text.len_lines() {
+                        break;
+                    }
+                    for col in 0..inner.width {
+                        if let Some(style) = session.cell_style(doc_line as u16, col) {
+                            surface[(inner.x + col, inner.y + y)].set_style(style);
+                        }
+                    }
+                }
+            }
 
             // if we're not at the edge of the screen, draw a right border
             if viewport.right() != view.area.right() {
@@ -553,13 +598,14 @@ impl EditorView {
         theme: &Theme,
         cursor_shape_config: &CursorShapeConfig,
         is_terminal_focused: bool,
+        force_block_cursor: bool,
     ) -> OverlayHighlights {
         let text = doc.text().slice(..);
         let selection = doc.selection(view.id);
         let primary_idx = selection.primary_index();
 
         let cursorkind = cursor_shape_config.from_mode(mode);
-        let cursor_is_block = cursorkind == CursorKind::Block;
+        let cursor_is_block = force_block_cursor || cursorkind == CursorKind::Block;
 
         let selection_scope = theme
             .find_highlight_exact("ui.selection")
@@ -1053,6 +1099,83 @@ impl EditorView {
         }
     }
 
+    /// Route a key typed while a terminal buffer has insert-mode focus to the
+    /// child process, bypassing the normal insert-mode keymap entirely (a
+    /// user's Insert-mode remaps, e.g. `jj` -> escape, must not eat keystrokes
+    /// meant for the shell). Two ways to detach back to Normal mode:
+    ///
+    /// - `<F12>` on its own: a single press, always available. Function keys
+    ///   decode the same way across every input backend we've seen, unlike
+    ///   `<C-\>` below, and no real terminal program binds F12, so it's safe
+    ///   to intercept unconditionally.
+    /// - `<C-\><C-n>`, the same chord Neovim uses for terminal-job mode, kept
+    ///   for muscle memory. Less reliable: different input backends report
+    ///   `<C-\>` differently (this build's reports it as `Char('4')`, the
+    ///   legacy ASCII-control-table reading of FS/0x1c, not `Char('\\')`) —
+    ///   if a given terminal reports it some third way we haven't seen, this
+    ///   chord silently won't fire, which is exactly why F12 exists as a
+    ///   backstop that doesn't depend on guessing key-decoding quirks.
+    ///
+    /// `<C-h/j/k/l>` jump to the adjacent split and detach to Normal mode
+    /// (same as F12, plus moving focus) instead of forwarding to the child
+    /// process — requested to match tmux/vim-style pane navigation muscle
+    /// memory. Trade-off worth knowing: `<C-h>` and `<C-j>` are also the
+    /// literal Backspace/Linefeed control bytes some shells and REPLs rely
+    /// on (e.g. a `stty erase ^H` setup, or a multi-line REPL using `<C-j>`
+    /// for a literal newline) — those no longer reach the child from inside
+    /// a terminal buffer.
+    fn handle_terminal_key(
+        &mut self,
+        cx: &mut commands::Context,
+        session: &term_pty::PtySession,
+        key: KeyEvent,
+    ) {
+        if key.code == KeyCode::F(12) && key.modifiers.is_empty() {
+            self.terminal_detach_pending = false;
+            cx.editor.mode = Mode::Normal;
+            return;
+        }
+
+        if key.modifiers == KeyModifiers::CONTROL {
+            let split_direction = match key.code {
+                KeyCode::Char('h') => Some(SplitDirection::Left),
+                KeyCode::Char('j') => Some(SplitDirection::Down),
+                KeyCode::Char('k') => Some(SplitDirection::Up),
+                KeyCode::Char('l') => Some(SplitDirection::Right),
+                _ => None,
+            };
+            if let Some(direction) = split_direction {
+                self.terminal_detach_pending = false;
+                cx.editor.mode = Mode::Normal;
+                cx.editor.focus_direction(direction);
+                return;
+            }
+        }
+
+        let is_detach_prefix = matches!(key.code, KeyCode::Char('\\') | KeyCode::Char('4'))
+            && key.modifiers == KeyModifiers::CONTROL;
+        let is_detach_confirm =
+            key.code == KeyCode::Char('n') && key.modifiers == KeyModifiers::CONTROL;
+
+        if self.terminal_detach_pending {
+            self.terminal_detach_pending = false;
+            if is_detach_confirm {
+                cx.editor.mode = Mode::Normal;
+                return;
+            }
+            // Not actually a detach sequence: the buffered `<C-\>` was meant
+            // for the child process, so send it before handling this key.
+            session.write_input(&[0x1c]);
+        } else if is_detach_prefix {
+            self.terminal_detach_pending = true;
+            return;
+        }
+
+        if let Some(bytes) = term_pty::encode_key(&key, session.application_cursor()) {
+            session.write_input(&bytes);
+        }
+    }
+
     fn command_mode(&mut self, mode: Mode, cxt: &mut commands::Context, event: KeyEvent) {
         match (event, cxt.editor.count) {
             // If the count is already started and the input is a number, always continue the count.
@@ -1539,8 +1662,17 @@ impl Component for EditorView {
                 let mode = cx.editor.mode();
 
                 if !self.on_next_key(OnKeyCallbackKind::PseudoPending, &mut cx, key) {
-                    match mode {
-                        Mode::Insert => {
+                    let terminal_session = if mode == Mode::Insert {
+                        term_pty::get(current!(cx.editor).1.id())
+                    } else {
+                        None
+                    };
+
+                    match (mode, terminal_session) {
+                        (Mode::Insert, Some(session)) => {
+                            self.handle_terminal_key(&mut cx, &session, key);
+                        }
+                        (Mode::Insert, None) => {
                             // let completion swallow the event if necessary
                             let mut consumed = false;
                             if let Some(completion) = &mut self.completion {
@@ -1590,7 +1722,7 @@ impl Component for EditorView {
                                 self.last_insert.1.push(InsertEvent::Key(key));
                             }
                         }
-                        mode => self.command_mode(mode, &mut cx, key),
+                        (mode, _) => self.command_mode(mode, &mut cx, key),
                     }
                 }
 
@@ -1613,7 +1745,15 @@ impl Component for EditorView {
                 let mode = cx.editor.mode();
                 let (view, doc) = current!(cx.editor);
 
-                view.ensure_cursor_in_view(doc, config.scrolloff);
+                // A terminal buffer always shows the vt100 grid from row 0 —
+                // "scroll to keep the cursor in view with scrolloff padding"
+                // is a text-buffer concept that doesn't apply and actively
+                // fights `refresh_document`'s cursor-position sync, which
+                // moves the selection to wherever the child program's
+                // cursor is (anywhere on screen) on basically every render.
+                if !term_pty::is_terminal(doc.id()) {
+                    view.ensure_cursor_in_view(doc, config.scrolloff);
+                }
 
                 // Store a history state if not in insert mode. This also takes care of
                 // committing changes when leaving insert mode.
@@ -1707,7 +1847,9 @@ impl Component for EditorView {
             cx.editor
                 .tree
                 .views()
-                .map(|(view, is_focused)| (view.id, if suppress_cursor { false } else { is_focused }))
+                .map(|(view, is_focused)| {
+                    (view.id, if suppress_cursor { false } else { is_focused })
+                })
                 .collect()
         };
         for (view_id, is_focused) in views {
@@ -1810,17 +1952,22 @@ impl Component for EditorView {
     }
 
     fn cursor(&self, _area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
-        match editor.cursor() {
-            // all block cursors are drawn manually
-            (pos, CursorKind::Block) => {
-                if self.terminal_focused {
-                    (pos, CursorKind::Hidden)
-                } else {
-                    // use terminal cursor when terminal loses focus
-                    (pos, CursorKind::Underline)
-                }
+        let (_, doc) = current_ref!(editor);
+        let is_terminal_doc = term_pty::is_terminal(doc.id());
+        let (pos, kind) = editor.cursor();
+        // All block cursors are drawn manually — and so is a terminal
+        // buffer's cursor unconditionally, regardless of the shape
+        // configured for Insert mode generally (see the matching
+        // `force_block_cursor` in `doc_selection_highlights`).
+        if kind == CursorKind::Block || is_terminal_doc {
+            if self.terminal_focused {
+                (pos, CursorKind::Hidden)
+            } else {
+                // use terminal cursor when terminal loses focus
+                (pos, CursorKind::Underline)
             }
-            cursor => cursor,
+        } else {
+            (pos, kind)
         }
     }
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -31,7 +31,7 @@ use helix_view::{
     keyboard::{KeyCode, KeyModifiers},
     Document, DocumentId, Editor, Theme, View, ViewId,
 };
-use std::{mem::take, num::NonZeroUsize, ops, path::PathBuf, rc::Rc};
+use std::{mem::take, num::NonZeroUsize, ops, rc::Rc};
 
 use tui::{buffer::Buffer as Surface, text::Span};
 
@@ -692,7 +692,6 @@ impl EditorView {
 
     /// Render bufferline at the top
     pub fn render_bufferline(editor: &Editor, viewport: Rect, surface: &mut Surface) {
-        let scratch = PathBuf::from(SCRATCH_BUFFER_NAME); // default filename to use for scratch buffer
         surface.clear_with(
             viewport,
             editor
@@ -715,13 +714,19 @@ impl EditorView {
         let current_doc = view!(editor).doc;
 
         for doc in editor.documents() {
-            let fname = doc
-                .path()
-                .unwrap_or(&scratch)
-                .file_name()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default();
+            let fname = match doc.path() {
+                Some(path) => path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default(),
+                // No real path - prefer a plugin-set short tab label (e.g.
+                // "oil" for a file-manager buffer) over the generic marker.
+                None => doc
+                    .bufferline_name
+                    .as_deref()
+                    .unwrap_or(SCRATCH_BUFFER_NAME),
+            };
 
             let style = if current_doc == doc.id() {
                 bufferline_active

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1766,7 +1766,17 @@ impl Component for EditorView {
 
                 // Store a history state if not in insert mode. This also takes care of
                 // committing changes when leaving insert mode.
-                if mode != Mode::Insert {
+                //
+                // Skipped for terminal buffers: their content changes every
+                // frame from `refresh_document`, not from user edits, so
+                // committing it here would both pollute undo with per-frame
+                // screen diffs and (since it advances the history revision
+                // counter) make `is_modified` report `true` forever after
+                // the next keypress that reaches this far in Normal mode
+                // (e.g. the `<F12>` that detaches from it) — `discard_pending_changes`
+                // in `term_pty::refresh_document` is what's meant to keep it
+                // clean instead.
+                if mode != Mode::Insert && !term_pty::is_terminal(doc.id()) {
                     doc.append_changes_to_history(view);
                 }
                 let callback = if callbacks.is_empty() {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -95,7 +95,16 @@ impl EditorView {
         {
             let editor = &cx.editor;
 
-            let inner = view.inner_area(doc);
+            // A full-width blank/loading terminal reads as "a terminal";
+            // Helix's usual line-number gutter on top of it reads as "an
+            // empty file" — skip reserving that column at all for terminal
+            // buffers (configurable via term-buffer-hide-gutter!).
+            let hide_gutter = term_pty::is_terminal(doc_id) && term_pty::hide_gutter();
+            let inner = if hide_gutter {
+                view.area.clip_bottom(1) // still leave room for the statusline
+            } else {
+                view.inner_area(doc)
+            };
             // Only the focused view drives the pty's size: a terminal buffer
             // split into two views can't have two sizes, and resizing from
             // whichever view happened to render last would fight itself.
@@ -200,7 +209,7 @@ impl EditorView {
             }
 
             let gutter_overflow = view.gutter_offset(doc) == 0;
-            if !gutter_overflow {
+            if !gutter_overflow && !hide_gutter {
                 Self::render_gutter(
                     editor,
                     doc,

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -989,6 +989,67 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             // of an open document matches what's shown in the buffer.
             overlay_highlights.extend(EditorView::doc_script_highlights(doc, &cx.editor.theme));
 
+            // Merge-conflict marker highlighting, computed from the previewed text so
+            // it works even for files that are not open (e.g. a conflicts-file picker).
+            // Colours the "ours" and "theirs" regions the same as the diff scopes.
+            fn conflict_regions(
+                text: helix_core::RopeSlice,
+            ) -> (Vec<std::ops::Range<usize>>, Vec<std::ops::Range<usize>>) {
+                fn line_is_marker(line: helix_core::RopeSlice, ch: char) -> bool {
+                    let mut chars = line.chars();
+                    for _ in 0..7 {
+                        if chars.next() != Some(ch) {
+                            return false;
+                        }
+                    }
+                    let rest: String = chars.collect();
+                    rest.trim().is_empty() || rest.starts_with(' ')
+                }
+                let (mut ours, mut theirs) = (Vec::new(), Vec::new());
+                let n = text.len_lines();
+                let (mut start, mut sep): (Option<usize>, Option<usize>) = (None, None);
+                for i in 0..n {
+                    let line = text.line(i);
+                    if line_is_marker(line, '<') {
+                        start = Some(i);
+                        sep = None;
+                    } else if start.is_some() && sep.is_none() && line_is_marker(line, '=') {
+                        sep = Some(i);
+                    } else if let (Some(s), Some(se)) = (start, sep) {
+                        if line_is_marker(line, '>') {
+                            ours.push(text.line_to_char(s)..text.line_to_char(se));
+                            let end = if i + 1 < n {
+                                text.line_to_char(i + 1)
+                            } else {
+                                text.len_chars()
+                            };
+                            theirs.push(text.line_to_char(se)..end);
+                            start = None;
+                            sep = None;
+                        }
+                    }
+                }
+                (ours, theirs)
+            }
+
+            let (ours_ranges, theirs_ranges) = conflict_regions(doc.text().slice(..));
+            if !ours_ranges.is_empty() {
+                if let Some(highlight) = cx.editor.theme.find_highlight("diff.plus") {
+                    overlay_highlights.push(helix_core::syntax::OverlayHighlights::Homogeneous {
+                        highlight,
+                        ranges: ours_ranges,
+                    });
+                }
+            }
+            if !theirs_ranges.is_empty() {
+                if let Some(highlight) = cx.editor.theme.find_highlight("diff.delta") {
+                    overlay_highlights.push(helix_core::syntax::OverlayHighlights::Homogeneous {
+                        highlight,
+                        ranges: theirs_ranges,
+                    });
+                }
+            }
+
             let mut decorations = DecorationManager::default();
 
             if let Some((start, end)) = range {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -985,6 +985,10 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 &mut overlay_highlights,
             );
 
+            // Script-defined highlights (e.g. git-conflict ours/theirs) so a preview
+            // of an open document matches what's shown in the buffer.
+            overlay_highlights.extend(EditorView::doc_script_highlights(doc, &cx.editor.theme));
+
             let mut decorations = DecorationManager::default();
 
             if let Some((start, end)) = range {

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -195,6 +195,19 @@ where
 {
     let visible = context.focused;
     let config = context.editor.config();
+
+    if visible {
+        if let Some(name) = context.editor.steel_mode.clone() {
+            let style = if config.color_modes {
+                context.editor.theme.get("ui.statusline.select")
+            } else {
+                Style::default()
+            };
+            write(context, Span::styled(format!(" {} ", name), style));
+            return;
+        }
+    }
+
     let modenames = &config.statusline.mode;
     let mode_str = match context.editor.mode() {
         Mode::Insert => &modenames.insert,

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -499,10 +499,13 @@ where
 {
     let doc = get_doc(context);
     let title = {
-        let rel_path = doc.relative_path();
-        let path = rel_path
+        // A plugin-set short label (e.g. "ours"/"theirs" for a merge-conflict
+        // side pane) always wins when set, matching the bufferline tab.
+        let path = doc
+            .bufferline_name
             .as_ref()
-            .map(|p| p.to_string_lossy())
+            .map(|n| n.into())
+            .or_else(|| doc.relative_path().as_ref().map(|p| p.to_string_lossy()))
             .or_else(|| doc.name.as_ref().map(|x| x.into()))
             .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
         format!(" {} ", path)
@@ -557,10 +560,15 @@ where
 {
     let doc = get_doc(context);
     let title = {
-        let rel_path = doc.relative_path();
-        let path = rel_path
+        let path = doc
+            .bufferline_name
             .as_ref()
-            .and_then(|p| p.file_name().map(|s| s.to_string_lossy()))
+            .map(|n| n.into())
+            .or_else(|| {
+                doc.relative_path()
+                    .as_ref()
+                    .and_then(|p| p.file_name().map(|s| s.to_string_lossy()))
+            })
             .or_else(|| doc.name.as_ref().map(|x| x.into()))
             .unwrap_or_else(|| SCRATCH_BUFFER_NAME.into());
         format!(" {} ", path)

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -208,11 +208,22 @@ where
         }
     }
 
+    let mode = context.editor.mode();
+    // A terminal buffer's "Insert" mode is really passthrough to the child
+    // process, not text editing — Neovim distinguishes this with its own
+    // "Terminal" mode label, so mirror that here rather than showing the
+    // same INS a real text buffer would.
+    let is_terminal_insert = mode == Mode::Insert && crate::term_pty::is_terminal(context.doc_id);
+
     let modenames = &config.statusline.mode;
-    let mode_str = match context.editor.mode() {
-        Mode::Insert => &modenames.insert,
-        Mode::Select => &modenames.select,
-        Mode::Normal => &modenames.normal,
+    let mode_str = if is_terminal_insert {
+        "TERM"
+    } else {
+        match mode {
+            Mode::Insert => &modenames.insert,
+            Mode::Select => &modenames.select,
+            Mode::Normal => &modenames.normal,
+        }
     };
     let content = if visible {
         format!(" {mode_str} ")
@@ -221,7 +232,7 @@ where
         " ".repeat(mode_str.width() + 2)
     };
     let style = if visible && config.color_modes {
-        match context.editor.mode() {
+        match mode {
             Mode::Insert => context.editor.theme.get("ui.statusline.insert"),
             Mode::Select => context.editor.theme.get("ui.statusline.select"),
             Mode::Normal => context.editor.theme.get("ui.statusline.normal"),

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -153,6 +153,8 @@ pub struct Document {
     pub(crate) jump_labels: HashMap<ViewId, Vec<Overlay>>,
     /// LSP document highlights for each view, stored as char ranges.
     pub(crate) document_highlights: HashMap<ViewId, DocumentHighlights>,
+    /// Script-defined highlight groups, keyed by namespace string.
+    pub(crate) script_highlights: HashMap<String, ScriptHighlightGroup>,
     /// LSP code action hints for each view.
     pub(crate) code_action_hints: HashSet<ViewId>,
     /// Set to `true` when the document is updated, reset to `false` on the next inlay hints
@@ -251,6 +253,12 @@ pub struct DocumentColorSwatches {
 /// Highlight ranges returned by LSP `textDocument/documentHighlight` for a view.
 #[derive(Debug, Clone, Default)]
 pub struct DocumentHighlights {
+    pub ranges: Vec<std::ops::Range<usize>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ScriptHighlightGroup {
+    pub scope: String,
     pub ranges: Vec<std::ops::Range<usize>>,
 }
 
@@ -772,6 +780,7 @@ impl Document {
             readonly: false,
             jump_labels: HashMap::new(),
             document_highlights: HashMap::new(),
+            script_highlights: HashMap::new(),
             code_action_hints: HashSet::new(),
             color_swatches: None,
             document_links: Vec::new(),
@@ -1630,6 +1639,28 @@ impl Document {
             highlights.ranges = updated;
         }
 
+        for group in self.script_highlights.values_mut() {
+            let text_len = self.text.len_chars();
+            let mut updated = Vec::with_capacity(group.ranges.len());
+            for mut range in group.ranges.drain(..) {
+                changes.update_positions(
+                    [
+                        (&mut range.start, Assoc::After),
+                        (&mut range.end, Assoc::After),
+                    ]
+                    .into_iter(),
+                );
+                if range.start >= text_len {
+                    continue;
+                }
+                let end = range.end.min(text_len);
+                if range.start < end {
+                    updated.push(range.start..end);
+                }
+            }
+            group.ranges = updated;
+        }
+
         helix_event::dispatch(DocumentDidChange {
             doc: self,
             view: view_id,
@@ -2472,6 +2503,33 @@ impl Document {
         self.document_highlights
             .get(&view_id)
             .map(|highlights| highlights.ranges.as_slice())
+    }
+
+    pub fn set_script_highlights(
+        &mut self,
+        namespace: String,
+        scope: String,
+        mut ranges: Vec<std::ops::Range<usize>>,
+    ) {
+        if ranges.is_empty() {
+            self.script_highlights.remove(&namespace);
+            return;
+        }
+        ranges.sort_unstable_by_key(|r| r.start);
+        self.script_highlights
+            .insert(namespace, ScriptHighlightGroup { scope, ranges });
+    }
+
+    pub fn clear_script_highlights(&mut self, namespace: &str) {
+        self.script_highlights.remove(namespace);
+    }
+
+    pub fn clear_all_script_highlights(&mut self) {
+        self.script_highlights.clear();
+    }
+
+    pub fn script_highlights(&self) -> &HashMap<String, ScriptHighlightGroup> {
+        &self.script_highlights
     }
 
     pub fn document_highlight_controller(&mut self, view_id: ViewId) -> &mut TaskController {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -216,6 +216,10 @@ pub struct Document {
 
     // A name separate from the file name
     pub name: Option<String>,
+    // A short label for the bufferline tab, separate from both the file name
+    // and `name` above (which can be long - e.g. a full directory path - and
+    // is meant for the statusline, not a narrow tab).
+    pub bufferline_name: Option<String>,
     pub readonly: bool,
 
     pub previous_diagnostic_ids: HashMap<LanguageServerId, String>,
@@ -786,6 +790,7 @@ impl Document {
             version_control_head: None,
             focused_at: std::time::Instant::now(),
             name: None,
+            bufferline_name: None,
             readonly: false,
             jump_labels: HashMap::new(),
             document_highlights: HashMap::new(),

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -308,6 +308,13 @@ pub struct DocumentInlayHints {
     /// added first, then the regular inlay hints, then the `after` padding.
     pub padding_before_inlay_hints: Vec<InlineAnnotation>,
     pub padding_after_inlay_hints: Vec<InlineAnnotation>,
+
+    /// Inlay hints with an explicit theme scope, used by plugins for custom
+    /// per-hint coloring (e.g. crates.hx). Parallel to `scoped_inlay_hint_scopes`;
+    /// each scope name is resolved to a highlight at render time so the color
+    /// tracks theme changes.
+    pub scoped_inlay_hints: Vec<InlineAnnotation>,
+    pub scoped_inlay_hint_scopes: Vec<String>,
 }
 
 impl DocumentInlayHints {
@@ -320,6 +327,8 @@ impl DocumentInlayHints {
             other_inlay_hints: Vec::new(),
             padding_before_inlay_hints: Vec::new(),
             padding_after_inlay_hints: Vec::new(),
+            scoped_inlay_hints: Vec::new(),
+            scoped_inlay_hint_scopes: Vec::new(),
         }
     }
 }
@@ -1608,6 +1617,8 @@ impl Document {
                 other_inlay_hints,
                 padding_before_inlay_hints,
                 padding_after_inlay_hints,
+                scoped_inlay_hints,
+                scoped_inlay_hint_scopes: _,
             } = text_annotation;
 
             apply_inlay_hint_changes(padding_before_inlay_hints);
@@ -1615,6 +1626,7 @@ impl Document {
             apply_inlay_hint_changes(parameter_inlay_hints);
             apply_inlay_hint_changes(other_inlay_hints);
             apply_inlay_hint_changes(padding_after_inlay_hints);
+            apply_inlay_hint_changes(scoped_inlay_hints);
         }
 
         for highlights in self.document_highlights.values_mut() {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -221,6 +221,32 @@ pub struct Document {
     // is meant for the statusline, not a narrow tab).
     pub bufferline_name: Option<String>,
     pub readonly: bool,
+    /// Whether this document is a terminal buffer (a running child
+    /// process's PTY output kept live-synced into a `Document`, with no
+    /// backing file) rather than a normal buffer that merely happens to
+    /// have no path yet, like a genuinely empty scratch buffer. Two things
+    /// key off this:
+    ///
+    /// - Every view showing the document always renders (and places the
+    ///   cursor, and maps mouse coordinates) as if scrolled to
+    ///   `ViewPosition::default()`, ignoring whatever offset is actually
+    ///   stored for that view. A terminal buffer's content is always
+    ///   exactly the size of the viewport rather than scrollable text - a
+    ///   stored offset only exists because it's incidentally the same
+    ///   storage normal buffers use, and would otherwise drift out from
+    ///   under a background-refreshing terminal buffer (see
+    ///   `Document::apply`'s anchor remapping) with no per-keystroke
+    ///   correction to pull it back, since terminal buffers also skip
+    ///   `ensure_cursor_in_view`.
+    /// - `Editor::switch`'s "delete an empty scratch buffer when navigating
+    ///   away from it" cleanup does not apply. That heuristic identifies a
+    ///   scratch buffer by `path().is_none()`, which a terminal buffer also
+    ///   satisfies despite being neither empty nor disposable - without
+    ///   this exemption, switching away from any terminal buffer that
+    ///   happens to be unmodified (which, unlike a real edit, it always is;
+    ///   see `discard_pending_changes`) silently deletes the `Document`
+    ///   out from under its still-running child process.
+    pub is_terminal_buffer: bool,
 
     pub previous_diagnostic_ids: HashMap<LanguageServerId, String>,
 
@@ -792,6 +818,7 @@ impl Document {
             name: None,
             bufferline_name: None,
             readonly: false,
+            is_terminal_buffer: false,
             jump_labels: HashMap::new(),
             document_highlights: HashMap::new(),
             script_highlights: HashMap::new(),
@@ -1901,6 +1928,18 @@ impl Document {
         current_revision != self.last_saved_revision || !self.changes.is_empty()
     }
 
+    /// Discards change-tracking accumulated since the last history commit,
+    /// without committing it to undo history or touching the saved-revision
+    /// counter. Unlike `append_changes_to_history`, this doesn't require
+    /// `old_state` to be set, so it's safe to call even when nothing has
+    /// been recorded yet. For a document that never calls
+    /// `append_changes_to_history` at all (a terminal buffer, whose content
+    /// changes every frame but was never "edited" in any sense a user would
+    /// want to undo), this is what keeps `is_modified` reporting `false`.
+    pub fn discard_pending_changes(&mut self) {
+        self.changes = ChangeSet::new(self.text().slice(..));
+    }
+
     /// Save modifications to history, and so [`Self::is_modified`] will return false.
     pub fn reset_modified(&mut self) {
         let history = self.history.take();
@@ -2169,6 +2208,9 @@ impl Document {
     }
 
     pub fn view_offset(&self, view_id: ViewId) -> ViewPosition {
+        if self.is_terminal_buffer {
+            return ViewPosition::default();
+        }
         self.view_data(view_id).view_position
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2089,7 +2089,13 @@ impl Editor {
     }
 
     /// Generate an id for a new document and register it.
-    fn new_document(&mut self, mut doc: Document) -> DocumentId {
+    /// Registers `doc` and returns its new id, without switching any view to
+    /// show it. Used by terminal-buffer-mode to spawn a pty attached to a
+    /// document that isn't visible yet, so a slow-to-start child process
+    /// (shell fork/exec + its own startup) doesn't flash an empty buffer
+    /// before there's real output to reveal — see `helix-term`'s
+    /// `term_pty::PtySession`.
+    pub fn new_document(&mut self, mut doc: Document) -> DocumentId {
         let id = self.next_document_id;
         // Safety: adding 1 from 1 is fine, practically impossible to reach usize max
         self.next_document_id =

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1999,7 +1999,10 @@ impl Editor {
                 // of `self.tree`, which is mutably borrowed when `view_mut` is called.
                 let remove_empty_scratch = !doc.is_modified()
                     // If the buffer has no path and is not modified, it is an empty scratch buffer.
+                    // A terminal buffer also has no path, but isn't empty or disposable -
+                    // see `Document::is_terminal_buffer`.
                     && doc.path().is_none()
+                    && !doc.is_terminal_buffer
                     // If the buffer we are changing to is not this buffer
                     && id != doc.id
                     // Ensure the buffer is not displayed in any other splits.

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1366,6 +1366,10 @@ pub struct Editor {
     pub editor_clipping: ClippingConfiguration,
 
     pub workspace_trust: WorkspaceTrust,
+
+    /// Active Steel-defined mode name, shown in the statusline instead of the
+    /// normal mode label. `None` means no Steel mode is active.
+    pub steel_mode: Option<String>,
 }
 
 #[derive(Default)]
@@ -1501,6 +1505,7 @@ impl Editor {
             editor_clipping: ClippingConfiguration::default(),
             dir_stack: VecDeque::with_capacity(DIR_STACK_CAP),
             workspace_trust,
+            steel_mode: None,
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1365,6 +1365,10 @@ pub struct Editor {
 
     pub editor_clipping: ClippingConfiguration,
 
+    /// When true, a Steel terminal component has focus; helix views render without
+    /// a focused-cursor highlight so only the PTY cursor is visible.
+    pub steel_terminal_has_focus: bool,
+
     pub workspace_trust: WorkspaceTrust,
 
     /// Active Steel-defined mode name, shown in the statusline instead of the
@@ -1503,6 +1507,7 @@ impl Editor {
             mouse_down_range: None,
             cursor_cache: CursorCache::default(),
             editor_clipping: ClippingConfiguration::default(),
+            steel_terminal_has_focus: false,
             dir_stack: VecDeque::with_capacity(DIR_STACK_CAP),
             workspace_trust,
             steel_mode: None,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2345,11 +2345,17 @@ impl Editor {
         let prev_id = std::mem::replace(&mut self.tree.focus, view_id);
         doc_mut!(self).mark_as_focused();
 
-        let focus_lost = self.tree.get(prev_id).doc;
-        dispatch(DocumentFocusLost {
-            editor: self,
-            doc: focus_lost,
-        });
+        // `prev_id` can already be gone from the tree here - e.g. if it was
+        // an empty scratch view removed as a side effect of the work above
+        // (enter_normal_mode/ensure_cursor_in_view/the sync_changes loop).
+        // Nothing meaningful lost focus in that case, so just skip the
+        // dispatch rather than unwrap a stale ViewId.
+        if let Some(focus_lost) = self.tree.try_get(prev_id).map(|view| view.doc) {
+            dispatch(DocumentFocusLost {
+                editor: self,
+                doc: focus_lost,
+            });
+        }
     }
 
     pub fn focus_next(&mut self) {

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -41,7 +41,7 @@ events! {
         kind: String,
         title: Option<String>,
         message: Option<String>,
-        percentage: Option<u32>,
+        percentage: Option<u32>
     }
 
     // NOTE: this event is simple for now and is expected to change as the config system evolves.

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -36,7 +36,7 @@ events! {
     }
 
     LspProgressUpdate {
-        server_id: LanguageServerId,
+        server_name: String,
         token: String,
         kind: String,
         title: Option<String>,

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -35,6 +35,18 @@ events! {
         server_id: LanguageServerId
     }
 
+    /// Fired for every WorkDoneProgress begin/report/end notification.
+    /// Uses owned data so it can be dispatched without holding an Editor borrow.
+    LspProgressUpdate {
+        server_id: LanguageServerId,
+        token: String,
+        /// "begin" | "report" | "end"
+        kind: String,
+        title: Option<String>,
+        message: Option<String>,
+        percentage: Option<u32>,
+    }
+
     // NOTE: this event is simple for now and is expected to change as the config system evolves.
     // Ideally it would say what changed.
     ConfigDidChange<'a> {

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -38,7 +38,6 @@ events! {
     LspProgressUpdate {
         server_id: LanguageServerId,
         token: String,
-        /// "begin" | "report" | "end"
         kind: String,
         title: Option<String>,
         message: Option<String>,

--- a/helix-view/src/events.rs
+++ b/helix-view/src/events.rs
@@ -35,8 +35,6 @@ events! {
         server_id: LanguageServerId
     }
 
-    /// Fired for every WorkDoneProgress begin/report/end notification.
-    /// Uses owned data so it can be dispatched without holding an Editor borrow.
     LspProgressUpdate {
         server_id: LanguageServerId,
         token: String,

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -474,6 +474,8 @@ impl View {
             other_inlay_hints,
             padding_before_inlay_hints,
             padding_after_inlay_hints,
+            scoped_inlay_hints,
+            scoped_inlay_hint_scopes,
         }) = doc.inlay_hints.get(&self.id)
         {
             let type_style = theme.and_then(|t| t.find_highlight("ui.virtual.inlay-hint.type"));
@@ -490,6 +492,14 @@ impl View {
                 .add_inline_annotations(parameter_inlay_hints, parameter_style)
                 .add_inline_annotations(other_inlay_hints, other_style)
                 .add_inline_annotations(padding_after_inlay_hints, None);
+
+            // Plugin-provided hints carry an explicit theme scope, resolved here
+            // so the color follows the active theme. Each is its own single-item
+            // layer (like color swatches), so no cross-hint sort is required.
+            for (annotation, scope) in scoped_inlay_hints.iter().zip(scoped_inlay_hint_scopes) {
+                let style = theme.and_then(|t| t.find_highlight(scope));
+                text_annotations.add_inline_annotations(std::slice::from_ref(annotation), style);
+            }
         };
         let config = doc.config.load();
 

--- a/languages.toml
+++ b/languages.toml
@@ -5509,3 +5509,16 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "concerto"
 source = { git = "https://github.com/accordproject/concerto-tree-sitter", rev = "920ba23ea93af56b19dfc38fcddf80b3ddc62685" }
+
+[[language]]
+name = "rstml"
+scope = "source.rstml"
+injection-regex = "rstml"
+file-types = []
+indent = { tab-width = 2, unit = "  " }
+block-comment-tokens = { start = "<!--", end = "-->" }
+grammar = "rstml"
+
+[[grammar]]
+name = "rstml"
+source = { git = "https://github.com/rayliwell/tree-sitter-rstml", rev = "2d4c2bc84a40d99a4e099ff7c6cf7f1bc5dc7806", subpath = "rstml" }

--- a/runtime/queries/rstml/highlights.scm
+++ b/runtime/queries/rstml/highlights.scm
@@ -1,0 +1,28 @@
+(doctype_node) @constant
+
+(doctype_node ["<!" ">"] @tag.delimiter)
+
+(open_tag ["<" ">"] @tag.delimiter)
+
+(close_tag ["</" ">"] @tag.delimiter)
+
+(self_closing_element_node ["<" "/>"] @tag.delimiter)
+
+(node_identifier ["-" ":" "::"] @punctuation.delimiter)
+
+(open_tag name: (node_identifier) @tag)
+
+(close_tag name: (node_identifier) @tag)
+
+(self_closing_element_node name: (node_identifier) @tag)
+
+(node_attribute name: (node_identifier) @tag.attribute)
+
+(generic_identifier
+  ["<" ">"] @punctuation.delimiter
+  (node_identifier) @tag)
+
+(text_node) @string
+
+(comment_node ["<!--" "-->"] @comment)
+(comment_node) @comment

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -35,6 +35,18 @@
        (identifier) @_macro_name
      ]
    (token_tree) @injection.content)
+ (#any-of? @_macro_name "view" "html_view")
+ (#set! injection.language "rstml")
+ (#set! injection.include-children))
+
+((macro_invocation
+   macro:
+     [
+       (scoped_identifier
+         name: (_) @_macro_name)
+       (identifier) @_macro_name
+     ]
+   (token_tree) @injection.content)
  (#eq? @_macro_name "slint")
  (#set! injection.language "slint")
  (#set! injection.include-children))

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -35,7 +35,7 @@
        (identifier) @_macro_name
      ]
    (token_tree) @injection.content)
- (#any-of? @_macro_name "view" "html_view")
+ (#any-of? @_macro_name "view" "html_view" "rsx")
  (#set! injection.language "rstml")
  (#set! injection.include-children))
 

--- a/steel-docs.md
+++ b/steel-docs.md
@@ -1,1351 +1,76 @@
-# /home/matt/.steel/cogs/helix/keymaps.scm
-### ***reverse-buffer-map-insert***
-Insert a value into the reverse buffer map
-### **set-global-buffer-or-extension-keymap**
-Check that the types on this map check out, otherwise we don't need to consistently do these checks
-### **query-global-keymap**
-Query the global keybindings.
+# /home/roastbeefer/.local/share/steel/cogs/helix/static.scm
+### **insert_char**
+Insert a given character at the cursor cursor position
+### **insert_string**
+Insert a given string at the current cursor position
+### **set-current-selection-object!**
+Update the selection object to the current selection within the editor
+### **push-range-to-selection!**
+Push a new range to a selection. The new selection will be the primary one
+### **set-current-selection-primary-index!**
+Set the primary index of the current selection
+### **remove-current-selection-range!**
+Remove a range from the current selection
+### **regex-selection**
+Run the given regex within the existing buffer
+### **replace-selection-with**
+Replace the existing selection with the given string
+### **enqueue-expression-in-engine**
+Enqueue an expression to run at the top level context,
+       after the existing function context has exited.
+### **get-current-line-character**
+Returns the current column number with the given position encoding
+### **cx->current-file**
+Get the currently focused file path
+### **current_selection**
+Returns the current selection as a string
+### **current-selection->string**
+Returns the current selection as a string
+### **load-buffer!**
+Evaluates the current buffer
+### **current-highlighted-text!**
+Returns the currently highlighted text as a string
+### **get-current-line-number**
+Returns the current line number
+### **get-current-column-number**
+Returns the visual current column number of unicode graphemes
+### **current-selection-object**
+Returns the current selection object
+### **get-helix-cwd**
+Returns the current working directly that helix is using
+### **move-window-far-left**
+Moves the current window to the far left
+### **move-window-far-right**
+Moves the current window to the far right
+### **selection->primary-index**
+Returns index of the primary selection
+### **selection->primary-range**
+Returns the range for primary selection
+### **selection->ranges**
+Returns all ranges of the selection
+### **range-anchor**
+Get the anchor of the range: the side that doesn't move when extending.
+### **range->from**
+Get the start of the range
+### **range-head**
+Get the head of the range, moved when extending.
+### **range->to**
+Get the end of the range
+### **range->span**
+Get the span of the range (from, to)
+### **range**
+Construct a new range object
 
 ```scheme
-(query-global-keymap "normal" '("space" "f")) ;; => "file_picker"
-```
-### **add-global-keybinding**
-Add keybinding to the global default
-### **deep-copy-global-keybindings**
-Deep copy the global keymap
-### **keymap**
-# /home/matt/.steel/cogs/helix/configuration.scm
-### **statusline**
-Configuration of the statusline elements.
-The following status line elements can be configured:
-
-Key	                        Description
--------------------------------------------------------------------------------------------
-mode	                        The current editor mode (mode.normal/mode.insert/mode.select)
-spinner	                    A progress spinner indicating LSP activity
-file-name	                The path/name of the opened file
-file-absolute-path	        The absolute path/name of the opened file
-file-base-name	            The basename of the opened file
-file-modification-indicator	The indicator to show whether the file is modified (a [+] appears when there are unsaved changes)
-file-encoding	            The encoding of the opened file if it differs from UTF-8
-file-line-ending	            The file line endings (CRLF or LF)
-file-indent-style	        The file indentation style
-read-only-indicator	        An indicator that shows [readonly] when a file cannot be written
-total-line-numbers	        The total line numbers of the opened file
-file-type	                The type of the opened file
-diagnostics	                The number of warnings and/or errors
-workspace-diagnostics	    The number of warnings and/or errors on workspace
-selections	                The primary selection index out of the number of active selections
-primary-selection-length	    The number of characters currently in primary selection
-position	                    The cursor position
-position-percentage	        The cursor position as a percentage of the total number of lines
-separator	                The string defined in editor.statusline.separator (defaults to "│")
-spacer	                    Inserts a space between elements (multiple/contiguous spacers may be specified)
-version-control	            The current branch name or detached commit hash of the opened workspace
-register	                    The current selected register
-### **indent-heuristic**
-Which indent heuristic to use when a new line is inserted
-Defaults to `"hybrid"`
-Valid options are:
-* "simple"
-* "tree-sitter"
-* "hybrid"
-### **atomic-save**
-Whether to use atomic operations to write documents to disk.
-This prevents data loss if the editor is interrupted while writing the file, but may
-confuse some file watching/hot reloading programs. Defaults to `#true`.
-### **lsp**
-Blanket LSP configuration
-The options are provided in a hashmap, and provided options will be merged
-with the defaults. The options are as follows:
-
-Enables LSP
-* enable: bool
-
-Display LSP messagess from $/progress below statusline
-* display-progress-messages: bool
-
-Display LSP messages from window/showMessage below statusline
-* display-messages: bool
-
-Enable automatic pop up of signature help (parameter hints)
-* auto-signature-help: bool
-
-Display docs under signature help popup
-* display-signature-help-docs: bool
-
-Display inlay hints
-* display-inlay-hints: bool
-
-Maximum displayed length of inlay hints (excluding the added trailing `…`).
-If it's `None`, there's no limit
-* inlay-hints-length-limit: Option<NonZeroU8>
-
-Display document color swatches
-* display-color-swatches: bool
-
-Whether to enable snippet support
-* snippets: bool
-
-Whether to include declaration in the goto reference query
-* goto_reference_include_declaration: bool
-
-```scheme
-(lsp (hash 'display-inlay-hints #t))
+(range anchor head) -> Range?
 ```
 
-The defaults shown from the rust side are as follows:
-```rust
-        LspConfig {
-           enable: true,
-           display_progress_messages: false,
-           display_messages: true,
-           auto_signature_help: true,
-           display_signature_help_docs: true,
-           display_inlay_hints: false,
-           inlay_hints_length_limit: None,
-           snippets: true,
-           goto_reference_include_declaration: true,
-           display_color_swatches: true,
-       }
-
-```
-### **search**
-Search configuration
-Accepts two keywords, #:smart-case and #:wrap-around, both default to true.
-
-```scheme
-(search #:smart-case #t #:wrap-around #t)
-(search #:smart-case #f #:wrap-around #f)
-```
-### **auto-pairs**
-Automatic insertion of pairs to parentheses, brackets,
-etc. Optionally, this can be a list of pairs to specify a
-global list of characters to pair, or a hashmap of character to character.
-Defaults to true.
-
-```scheme
-(auto-pairs #f)
-(auto-pairs #t)
-(auto-pairs (list '(#\{ . #\})))
-(auto-pairs (list '(#\{ #\})))
-(auto-pairs (list (cons #\{ #\})))
-(auto-pairs (hash #\{ #\}))
-```
-### **continue-comments**
-Whether comments should be continued.
-### **popup-border**
-Set the popup border.
-Valid options are:
-* "none"
-* "all"
-* "popup"
-* "menu"
-### **register-lsp-notification-handler**
-Register a callback to be called on LSP notifications sent from the server -> client
-that aren't currently handled by Helix as a built in.
-
-```scheme
-(register-lsp-notification-handler lsp-name event-name handler)
-```
-
-* lsp-name : string?
-* event-name : string?
-* function : (-> hash? any?) ;; Function where the first argument is the parameters
-
-# Examples
-```
-(register-lsp-notification-handler "dart"
-                                   "dart/textDocument/publishClosingLabels"
-                                   (lambda (args) (displayln args)))
-```
-### **register-lsp-call-handler**
-Register a callback to be called on LSP calls sent from the server -> client
-that aren't currently handled by Helix as a built in.
-
-```scheme
-(register-lsp-call-handler lsp-name event-name handler)
-```
-
-* lsp-name : string?
-* event-name : string?
-* function : (-> hash? any?) ;; Function where the first argument is the parameters
-
-# Examples
-```
-(register-lsp-call-handler "dart"
-                                   "dart/textDocument/publishClosingLabels"
-                                   (lambda (call-id args) (displayln args)))
-```
-### **define-lsp**
-Syntax:
-
-Registers an lsp configuration. This is a thin wrapper around passing
-a hashmap manually to `set-lsp-config!`, and has a slightly more elegant
-API.
-
-Examples:
-```scheme
-(define-lsp "steel-language-server" (command steel-language-server) (args '()))
-(define-lsp "rust-analyzer" (config (experimental (hash 'testExplorer #t 'runnables '("cargo")))))
-(define-lsp "tinymist" (config (exportPdf "onType") (outputPath "$root/$dir/$name")))
-```
-### **cursor-shape**
-Shape for cursor in each mode
-
-(cursor-shape #:normal (normal 'block)
-              #:select (select 'block)
-              #:insert (insert 'block))
-
-# Examples
-
-```scheme
-(cursor-shape #:normal 'block #:select 'underline #:insert 'bar)
-```
-### **get-lsp-config**
-Get the lsp configuration for a language server.
-
-Returns a hashmap which can be passed to `set-lsp-config!`
-### **set-lsp-config!**
-Sets the language server config for a specific language server.
-
-```scheme
-(set-lsp-config! lsp config)
-```
-* lsp : string?
-* config: hash?
-
-This will overlay the existing configuration, much like the existing
-toml definition does.
-
-Available options for the config hash are:
-```scheme
-(hash "command" "<command>"
-      "args" (list "args" ...)
-      "environment" (hash "ENV" "VAR" ...)
-      "config" (hash ...)
-      "timeout" 100 ;; number
-      "required-root-patterns" (listof "pattern" ...))
-
-```
-
-# Examples
-```
-(set-lsp-config! "jdtls"
-   (hash "args" (list "-data" "/home/matt/code/java-scratch/workspace")))
-```
-### **file-picker-kw**
-Sets the configuration for the file picker using keywords.
-
-```scheme
-(file-picker-kw #:hidden #t
-                #:follow-symlinks #t
-                #:deduplicate-links #t
-                #:parents #t
-                #:ignore #t
-                #:git-ignore #t
-                #:git-exclude #t
-                #:git-global #t
-                #:max-depth #f) ;; Expects either #f or an int?
-```
-By default, max depth is `#f` while everything else is an int?
-
-To use this, call this in your `init.scm` or `helix.scm`:
-
-# Examples
-```scheme
-(file-picker-kw #:hidden #f)
-```
-### **file-picker**
-Sets the configuration for the file picker using var args.
-
-```scheme
-(file-picker . args)
-```
-
-The args are expected to be something of the value:
-```scheme
-(-> FilePickerConfiguration? bool?)    
-```
-
-These other functions in this module which follow this behavior are all
-prefixed `fp-`, and include:
-
-* fp-hidden
-* fp-follow-symlinks
-* fp-deduplicate-links
-* fp-parents
-* fp-ignore
-* fp-git-ignore
-* fp-git-global
-* fp-git-exclude
-* fp-max-depth
-
-By default, max depth is `#f` while everything else is an int?
-
-To use this, call this in your `init.scm` or `helix.scm`:
-
-# Examples
-```scheme
-(file-picker (fp-hidden #f) (fp-parents #f))
-```
-### **soft-wrap-kw**
-Sets the configuration for soft wrap using keyword args.
-
-```scheme
-(soft-wrap-kw #:enable #f
-              #:max-wrap 20
-              #:max-indent-retain 40
-              #:wrap-indicator "↪"
-              #:wrap-at-text-width #f)
-```
-
-The options are as follows:
-
-* #:enable:
-  Soft wrap lines that exceed viewport width. Default to off
-* #:max-wrap:
-  Maximum space left free at the end of the line.
-  This space is used to wrap text at word boundaries. If that is not possible within this limit
-  the word is simply split at the end of the line.
-
-  This is automatically hard-limited to a quarter of the viewport to ensure correct display on small views.
-
-  Default to 20
-* #:max-indent-retain
-  Maximum number of indentation that can be carried over from the previous line when softwrapping.
-  If a line is indented further then this limit it is rendered at the start of the viewport instead.
-
-  This is automatically hard-limited to a quarter of the viewport to ensure correct display on small views.
-
-  Default to 40
-* #:wrap-indicator
-  Indicator placed at the beginning of softwrapped lines
-
-  Defaults to ↪
-* #:wrap-at-text-width
-  Softwrap at `text_width` instead of viewport width if it is shorter
-
-# Examples
-```scheme
-(soft-wrap-kw #:sw-enable #t)
-```
-### **soft-wrap**
-Sets the configuration for soft wrap using var args.
-
-```scheme
-(soft-wrap . args)
-```
-
-The args are expected to be something of the value:
-```scheme
-(-> SoftWrapConfiguration? bool?)    
-```
-The options are as follows:
-
-* sw-enable:
-  Soft wrap lines that exceed viewport width. Default to off
-* sw-max-wrap:
-  Maximum space left free at the end of the line.
-  This space is used to wrap text at word boundaries. If that is not possible within this limit
-  the word is simply split at the end of the line.
-
-  This is automatically hard-limited to a quarter of the viewport to ensure correct display on small views.
-
-  Default to 20
-* sw-max-indent-retain
-  Maximum number of indentation that can be carried over from the previous line when softwrapping.
-  If a line is indented further then this limit it is rendered at the start of the viewport instead.
-
-  This is automatically hard-limited to a quarter of the viewport to ensure correct display on small views.
-
-  Default to 40
-* sw-wrap-indicator
-  Indicator placed at the beginning of softwrapped lines
-
-  Defaults to ↪
-* sw-wrap-at-text-width
-  Softwrap at `text_width` instead of viewport width if it is shorter
-
-# Examples
-```scheme
-(soft-wrap (sw-enable #t))
-```
-### **whitespace**
-Sets the configuration for whitespace using var args.
-
-```scheme
-(whitespace . args)
-```
-
-The args are expected to be something of the value:
-```scheme
-(-> WhitespaceConfiguration? bool?)    
-```
-The options are as follows:
-
-* ws-visible:
-  Show all visible whitespace, defaults to false
-* ws-render:
-  manually disable or enable characters
-  render options (specified in hashmap):
-```scheme
-  (hash
-    'space #f
-    'nbsp #f
-    'nnbsp #f
-    'tab #f
-    'newline #f)
-```
-* ws-chars:
-  manually set visible whitespace characters with a hashmap
-  character options (specified in hashmap):
-```scheme
-  (hash
-    'space #\·
-    'nbsp #\⍽
-    'nnbsp #\␣
-    'tab #\→
-    'newline #\⏎
-    ; Tabs will look like "→···" (depending on tab width)
-    'tabpad #\·)
-```
-# Examples
-```scheme
-(whitespace (ws-visible #t) (ws-chars (hash 'space #\·)) (ws-render (hash 'tab #f)))
-```
-### **indent-guides**
-Sets the configuration for indent-guides using args
-
-```scheme
-(indent-guides . args)
-```
-
-The args are expected to be something of the value:
-```scheme
-(-> IndentGuidesConfig? bool?)
-```
-The options are as follows:
-
-* ig-render:
-  Show indent guides, defaults to false
-* ig-character:
-  character used for indent guides, defaults to "╎"
-* ig-skip-levels:
-  amount of levels to skip, defaults to 1
-
-# Examples
-```scheme
-(indent-guides (ig-render #t) (ig-character #\|) (ig-skip-levels 1))
-```
-### **scrolloff**
-Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
-### **scroll_lines**
-Number of lines to scroll at once. Defaults to 3
-### **mouse**
-Mouse support. Defaults to true.
-### **shell**
-Shell to use for shell commands. Defaults to ["cmd", "/C"] on Windows and ["sh", "-c"] otherwise.
-### **jump-label-alphabet**
-The characters that are used to generate two character jump labels. Characters at the start of the alphabet are used first. Defaults to "abcdefghijklmnopqrstuvwxyz"
-### **line-number**
-Line number mode. Defaults to 'absolute, set to 'relative for relative line numbers
-### **cursorline**
-Highlight the lines cursors are currently on. Defaults to false
-### **cursorcolumn**
-Highlight the columns cursors are currently on. Defaults to false
-### **middle-click-paste**
-Middle click paste support. Defaults to true
-### **auto-completion**
-Automatic auto-completion, automatically pop up without user trigger. Defaults to true.
-### **auto-format**
-Automatic formatting on save. Defaults to true.
-### **auto-save**
-Automatic save on focus lost and/or after delay.
-Time delay in milliseconds since last edit after which auto save timer triggers.
-Time delay defaults to false with 3000ms delay. Focus lost defaults to false.
-               
-### **text-width**
-Set a global text_width
-### **idle-timeout**
-Time in milliseconds since last keypress before idle timers trigger.
-Used for various UI timeouts. Defaults to 250ms.
-### **completion-timeout**
-
-Time in milliseconds after typing a word character before auto completions
-are shown, set to 5 for instant. Defaults to 250ms.
-               
-### **preview-completion-insert**
-Whether to insert the completion suggestion on hover. Defaults to true.
-### **completion-trigger-len**
-Length to trigger completions
-### **completion-replace**
-Whether to instruct the LSP to replace the entire word when applying a completion
-or to only insert new text
-### **auto-info**
-Whether to display infoboxes. Defaults to true.
-### **true-color**
-Set to `true` to override automatic detection of terminal truecolor support in the event of a false negative. Defaults to `false`.
-### **insert-final-newline**
-Whether to automatically insert a trailing line-ending on write if missing. Defaults to `true`
-### **color-modes**
-Whether to color modes with different colors. Defaults to `false`.
-### **gutters**
-Gutter configuration
-### **undercurl**
-Set to `true` to override automatic detection of terminal undercurl support in the event of a false negative. Defaults to `false`.
-### **terminal**
-Terminal config
-### **rulers**
-Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers
-### **bufferline**
-Persistently display open buffers along the top
-### **workspace-lsp-roots**
-Workspace specific lsp ceiling dirs
-### **default-line-ending**
-Which line ending to choose for new documents. Defaults to `native`. i.e. `crlf` on Windows, otherwise `lf`.
-### **smart-tab**
-Enables smart tab
-### **rainbow-brackets**
-Enabled rainbow brackets
-### **keybindings**
-Keybindings config
-### **set-keybindings!**
-Override the global keybindings with the provided keymap
-### **inline-diagnostics-cursor-line-enable**
-Inline diagnostics cursor line
-### **inline-diagnostics-other-lines-enable**
-Inline diagnostics other lines
-### **inline-diagnostics-end-of-line-enable**
-Inline diagnostics end of line
-### **inline-diagnostics-min-diagnostics-width**
-Inline diagnostics min diagnostics width
-### **inline-diagnostics-prefix-len**
-Inline diagnostics prefix length
-### **inline-diagnostics-max-wrap**
-Inline diagnostics maximum wrap
-### **inline-diagnostics-max-diagnostics**
-Inline diagnostics max diagnostics
-### **get-language-config**
-Get the configuration for a specific language
-### **set-language-config!**
-Set the language configuration
-# /home/matt/.steel/cogs/helix/commands.scm
-### **quit**
-Close the current view.
-### **quit!**
-Force close the current view, ignoring unsaved changes.
-### **open**
-Open a file from disk into the current view.
-### **buffer-close**
-Close the current buffer.
-### **buffer-close!**
-Close the current buffer forcefully, ignoring unsaved changes.
-### **buffer-close-others**
-Close all buffers but the currently focused one.
-### **buffer-close-others!**
-Force close all buffers but the currently focused one.
-### **buffer-close-all**
-Close all buffers without quitting.
-### **buffer-close-all!**
-Force close all buffers ignoring unsaved changes without quitting.
-### **buffer-next**
-Goto next buffer.
-### **buffer-previous**
-Goto previous buffer.
-### **write**
-Write changes to disk. Accepts an optional path (:write some/path.txt)
-### **write!**
-Force write changes to disk creating necessary subdirectories. Accepts an optional path (:write! some/path.txt)
-### **write-buffer-close**
-Write changes to disk and closes the buffer. Accepts an optional path (:write-buffer-close some/path.txt)
-### **write-buffer-close!**
-Force write changes to disk creating necessary subdirectories and closes the buffer. Accepts an optional path (:write-buffer-close! some/path.txt)
-### **new**
-Create a new scratch buffer.
-### **format**
-Format the file using an external formatter or language server.
-### **indent-style**
-Set the indentation style for editing. ('t' for tabs or 1-16 for number of spaces.)
-### **line-ending**
-Set the document's default line ending. Options: crlf, lf.
-### **earlier**
-Jump back to an earlier point in edit history. Accepts a number of steps or a time span.
-### **later**
-Jump to a later point in edit history. Accepts a number of steps or a time span.
-### **write-quit**
-Write changes to disk and close the current view. Accepts an optional path (:wq some/path.txt)
-### **write-quit!**
-Write changes to disk and close the current view forcefully. Accepts an optional path (:wq! some/path.txt)
-### **write-all**
-Write changes from all buffers to disk.
-### **write-all!**
-Forcefully write changes from all buffers to disk creating necessary subdirectories.
-### **write-quit-all**
-Write changes from all buffers to disk and close all views.
-### **write-quit-all!**
-Write changes from all buffers to disk and close all views forcefully (ignoring unsaved changes).
-### **quit-all**
-Close all views.
-### **quit-all!**
-Force close all views ignoring unsaved changes.
-### **cquit**
-Quit with exit code (default 1). Accepts an optional integer exit code (:cq 2).
-### **cquit!**
-Force quit with exit code (default 1) ignoring unsaved changes. Accepts an optional integer exit code (:cq! 2).
-### **theme**
-Change the editor theme (show current theme if no name specified).
-### **yank-join**
-Yank joined selections. A separator can be provided as first argument. Default value is newline.
-### **clipboard-yank**
-Yank main selection into system clipboard.
-### **clipboard-yank-join**
-Yank joined selections into system clipboard. A separator can be provided as first argument. Default value is newline.
-### **primary-clipboard-yank**
-Yank main selection into system primary clipboard.
-### **primary-clipboard-yank-join**
-Yank joined selections into system primary clipboard. A separator can be provided as first argument. Default value is newline.
-### **clipboard-paste-after**
-Paste system clipboard after selections.
-### **clipboard-paste-before**
-Paste system clipboard before selections.
-### **clipboard-paste-replace**
-Replace selections with content of system clipboard.
-### **primary-clipboard-paste-after**
-Paste primary clipboard after selections.
-### **primary-clipboard-paste-before**
-Paste primary clipboard before selections.
-### **primary-clipboard-paste-replace**
-Replace selections with content of system primary clipboard.
-### **show-clipboard-provider**
-Show clipboard provider name in status bar.
-### **change-current-directory**
-Change the current working directory.
-### **show-directory**
-Show the current working directory.
-### **encoding**
-Set encoding. Based on `https://encoding.spec.whatwg.org`.
-### **character-info**
-Get info about the character under the primary cursor.
-### **reload**
-Discard changes and reload from the source file.
-### **reload-all**
-Discard changes and reload all documents from the source files.
-### **update**
-Write changes only if the file has been modified.
-### **lsp-workspace-command**
-Open workspace command picker
-### **lsp-restart**
-Restarts the given language servers, or all language servers that are used by the current file if no arguments are supplied
-### **lsp-stop**
-Stops the given language servers, or all language servers that are used by the current file if no arguments are supplied
-### **tree-sitter-scopes**
-Display tree sitter scopes, primarily for theming and development.
-### **tree-sitter-highlight-name**
-Display name of tree-sitter highlight scope under the cursor.
-### **debug-start**
-Start a debug session from a given template with given parameters.
-### **debug-remote**
-Connect to a debug adapter by TCP address and start a debugging session from a given template with given parameters.
-### **debug-eval**
-Evaluate expression in current debug context.
-### **vsplit**
-Open the file in a vertical split.
-### **vsplit-new**
-Open a scratch buffer in a vertical split.
-### **hsplit**
-Open the file in a horizontal split.
-### **hsplit-new**
-Open a scratch buffer in a horizontal split.
-### **tutor**
-Open the tutorial.
-### **goto**
-Goto line number.
-### **set-language**
-Set the language of current buffer (show current language if no value specified).
-### **set-option**
-Set a config option at runtime.
-For example to disable smart case search, use `:set search.smart-case false`.
-### **toggle-option**
-Toggle a config option at runtime.
-For example to toggle smart case search, use `:toggle search.smart-case`.
-### **get-option**
-Get the current value of a config option.
-### **sort**
-Sort ranges in selection.
-### **reflow**
-Hard-wrap the current selection of lines to a given width.
-### **tree-sitter-subtree**
-Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries.
-### **config-reload**
-Refresh user config.
-### **config-open**
-Open the user config.toml file.
-### **config-open-workspace**
-Open the workspace config.toml file.
-### **log-open**
-Open the helix log file.
-### **insert-output**
-Run shell command, inserting output before each selection.
-### **append-output**
-Run shell command, appending output after each selection.
-### **pipe**
-Pipe each selection to the shell command.
-### **pipe-to**
-Pipe each selection to the shell command, ignoring output.
-### **run-shell-command**
-Run a shell command
-### **reset-diff-change**
-Reset the diff change at the cursor position.
-### **clear-register**
-Clear given register. If no argument is provided, clear all registers.
-### **redraw**
-Clear and re-render the whole UI
-### **move**
-Move the current buffer and its corresponding file to a different path
-### **yank-diagnostic**
-Yank diagnostic(s) under primary cursor to register, or clipboard by default
-### **read**
-Load a file into buffer
-### **echo**
-Prints the given arguments to the statusline.
-### **noop**
-Does nothing.
-### **goto-column**
-Move the cursor to the given character index within the same line
-### **goto-line**
-Move the cursor to the given line
-# /home/matt/.steel/cogs/helix/misc.scm
-### **hx.cx->pos**
-DEPRECATED: Please use `cursor-position`
-### **cursor-position**
-Returns the cursor position within the current buffer as an integer
-### **get-active-lsp-clients**
-Get all language servers, that are attached to the current buffer
-### **mode-switch-old**
-Return the old mode from the event payload
-### **mode-switch-new**
-Return the new mode from the event payload
-### **lsp-client-initialized?**
-Return if the lsp client is initialized
-### **lsp-client-name**
-Get the name of the lsp client
-### **lsp-client-offset-encoding**
-Get the offset encoding of the lsp client
-### **hx.custom-insert-newline**
-DEPRECATED: Please use `insert-newline-hook`
-### **insert-newline-hook**
-Inserts a new line with the provided indentation.
-
-```scheme
-(insert-newline-hook indent-string)
-```
-
-indent-string : string?
-
-### **push-component!**
-
-Push a component on to the top of the stack.
-
-```scheme
-(push-component! component)
-```
-
-component : WrappedDynComponent?
-       
-### **pop-last-component!**
-DEPRECATED: Please use `pop-last-component-by-name!`
-### **pop-last-component-by-name!**
-Pops the last component off of the stack by name. In other words,
-it removes the component matching this name from the stack.
-
-```scheme
-(pop-last-component-by-name! name)
-```
-
-name : string?
-       
-### **enqueue-thread-local-callback**
-
-Enqueue a function to be run following this context of execution. This could
-be useful for yielding back to the editor in the event you want updates to happen
-before your function is run.
-
-```scheme
-(enqueue-thread-local-callback callback)
-```
-
-callback : (-> any?)
-   Function with no arguments.
-
-# Examples
-
-```scheme
-(enqueue-thread-local-callback (lambda () (theme "focus_nova")))
-```
-       
-### **set-status!**
-Sets the content of the status line, with the info severity
-### **set-warning!**
-Sets the content of the status line, with the warning severity
-### **set-error!**
-Sets the content of the status line, with the error severity
-### **send-lsp-command**
-Send an lsp command. The `lsp-name` must correspond to an active lsp.
-The method name corresponds to the method name that you'd expect to see
-with the lsp, and the params can be passed as a hash table. The callback
-provided will be called with whatever result is returned from the LSP,
-deserialized from json to a steel value.
-
-# Example
-```scheme
-(define (view-crate-graph)
-  (send-lsp-command "rust-analyzer"
-                    "rust-analyzer/viewCrateGraph"
-                    (hash "full" #f)
-                    ;; Callback to run with the result
-                    (lambda (result) (displayln result))))
-```
-### **send-lsp-notification**
-Send an LSP notification. The `lsp-name` must correspond to an active LSP.
-The method name corresponds to the method name that you'd expect to see
-with the LSP, and the params can be passed as a hash table. Unlike
-`send-lsp-command`, this does not expect a response and is used for
-fire-and-forget notifications.
-
-# Example
-```scheme
-(send-lsp-notification "copilot"
-                       "textDocument/didShowCompletion"
-                       (hash "item"
-                             (hash "insertText" "a helpful suggestion"
-                                   "range" (hash "start" (hash "line" 1 "character" 0)
-                                                 "end" (hash "line" 1 "character" 2)))))
-```
-### **lsp-reply-ok**
-Send a successful reply to an LSP request with the given result.
-
-```scheme
-(lsp-reply-ok lsp-name request-id result)
-```
-
-* lsp-name : string? - Name of the language server
-* request-id : string? - ID of the request to respond to  
-* result : any? - The result value to send back
-
-# Examples
-```scheme
-;; Reply to a request with id "123" from rust-analyzer
-(lsp-reply-ok "rust-analyzer" "123" (hash "result" "value"))
-```
-### **acquire-context-lock**
-
-Schedule a function to run on the main thread. This is a fairly low level function, and odds are
-you'll want to use some abstractions on top of this.
-
-The provided function will get enqueued to run on the main thread, and during the duration of the functions
-execution, the provided mutex will be locked.
-
-```scheme
-(acquire-context-lock callback-fn mutex)
-```
-
-callback-fn : (-> void?)
-   Function with no arguments
-
-mutex : mutex?
-### **enqueue-thread-local-callback-with-delay**
-
-Enqueue a function to be run following this context of execution, after a delay. This could
-be useful for yielding back to the editor in the event you want updates to happen
-before your function is run.
-
-```scheme
-(enqueue-thread-local-callback-with-delay delay callback)
-```
-
-delay : int?
-   Time to delay the callback by in milliseconds
-
-callback : (-> any?)
-   Function with no arguments.
-
-# Examples
-
-```scheme
-(enqueue-thread-local-callback-with-delay 1000 (lambda () (theme "focus_nova"))) ;; Run after 1 second
-``
-       
-### **helix-await-callback**
-DEPRECATED: Please use `await-callback`
-### **await-callback**
-
-Await the given value, and call the callback function on once the future is completed.
-
-```scheme
-(await-callback future callback)
-```
-
-* future : future?
-* callback (-> any?)
-   Function with no arguments
-### **add-inlay-hint**
-
-Warning: this is experimental
-
-Adds an inlay hint at the given character index. Returns the (first-line, last-line) list
-associated with this snapshot of the inlay hints. Use this pair of line numbers to invalidate
-the inlay hints.
-
-```scheme
-(add-inlay-hint char-index completion) -> (list int? int?)
-```
-
-char-index : int?
-completion : string?
-
-### **remove-inlay-hint**
-
-Warning: this is experimental and should not be used.
-This will most likely be removed soon.
-
-Removes an inlay hint at the given character index. Note - to remove
-properly, the completion must match what was already there.
-
-```scheme
-(remove-inlay-hint char-index completion)
-```
-
-char-index : int?
-completion : string?
-
-### **remove-inlay-hint-by-id**
-
-Warning: this is experimental
-
-Removes an inlay hint by the id that was associated with the added inlay hints.
-
-```scheme
-(remove-inlay-hint first-line last-line)
-```
-
-first-line : int?
-last-line : int?
-
-# /home/matt/.steel/cogs/helix/editor.scm
-### **editor-focus**
-
-Get the current focus of the editor, as a `ViewId`.
-
-```scheme
-(editor-focus) -> ViewId
-```
-       
-### **editor-mode**
-
-Get the current mode of the editor
-
-```scheme
-(editor-mode) -> Mode?
-```
-       
-### **string->editor-mode**
-
-Create an editor mode from a string, or false if it string was not one of
-"normal", "insert", or "select"
-
-```scheme
-(string->editor-mode "normal") -> (or Mode? #f)
-```
-       
-### **cx->themes**
-DEPRECATED: Please use `themes->list`
-### **themes->list**
-
-Get the current themes as a list of strings.
-
-```scheme
-(themes->list) -> (listof string?)
-```
-       
-### **editor-all-documents**
-
-Get a list of all of the document ids that are currently open.
-
-```scheme
-(editor-all-documents) -> (listof DocumentId?)
-```
-       
-### **cx->cursor**
-DEPRECATED: Please use `current-cursor`
-### **current-cursor**
-Gets the primary cursor position in screen coordinates,
-or `#false` if the primary cursor is not visible on screen.
-
-```scheme
-(current-cursor) -> (listof? (or Position? #false) CursorKind)
-```
-       
-### **editor-focused-buffer-area**
-
-Get the `Rect` associated with the currently focused buffer.
-
-```scheme
-(editor-focused-buffer-area) -> (or Rect? #false)
-```
-       
-### **selected-register!**
-Get currently selected register
-### **editor->doc-id**
-Get the document from a given view.
-### **editor-switch!**
-Open the document in a vertical split.
-### **editor-set-focus!**
-Set focus on the view.
-### **editor-set-mode!**
-Set the editor mode.
-### **editor-doc-in-view?**
-Check whether the current view contains a document.
-### **set-scratch-buffer-name!**
-Set the name of a scratch buffer.
-### **set-buffer-uri!**
-Set the URI of the buffer
-### **editor-doc-exists?**
-Check if a document exists.
-### **editor-document-last-saved**
-Check when a document was last saved (returns a `SystemTime`)
-### **editor-document->language**
-Get the language for the document
-### **editor-document-dirty?**
-Check if a document has unsaved changes
-### **editor-document-reload**
-Reload a document.
-### **editor->text**
-Get the document as a rope.
-### **editor-document->path**
-Get the path to a document.
-### **register->value**
-Get register value as a list of strings.
-### **set-editor-clip-top!**
-Set the editor clipping at the top.
-### **set-editor-clip-right!**
-Set the editor clipping at the right.
-### **set-editor-clip-left!**
-Set the editor clipping at the left.
-### **set-editor-clip-bottom!**
-Set the editor clipping at the bottom.
-# /home/matt/.steel/cogs/helix/themes.scm
-### **register-theme**
-Register this theme with helix for use
-### **attribute**
-Class attributes, HTML tag attributes
-### **type**
-Types
-### **type.builtin**
-Primitive types provided by the language (`int`, `usize`)
-### **type.parameter**
-Generic type parameters (`T`)
-### **type.enum**
-Enum usage
-### **type.enum.variant**
-Enum variant
-### **constructor**
-Constructor usage
-### **constant**
-Constants usage
-### **constant.builtin**
-Special constants provided by the language (`true`, `false`, `nil`, etc)
-### **constant.builtin.boolean**
-A special case for highlighting individual booleans
-### **constant.character**
-Character usage
-### **constant.character.escape**
-Highlighting individual escape characters
-### **constant.numeric**
-Numbers
-### **constant.numeric.integer**
-Integers
-### **constant.numeric.float**
-Floats
-### **string**
-Highlighting strings
-### **string.regexp**
-Highlighting regular expressions
-### **string.special**
-Special strings
-### **string.special.path**
-Highlighting paths
-### **string.special.url**
-Highlighting URLs
-### **string.special.symbol**
-Erlang/Elixir atoms, Ruby symbols, Clojure keywords
-### **comment**
-Highlighting comments
-### **comment.line**
-Single line comments (`//`)
-### **comment.block**
-Block comments (`/* */`)
-### **comment.block.documentation**
-Documentation comments (e.g. `///` in Rust)
-### **variable**
-Variables
-### **variable.builtin**
-Reserved language variables (`self`, `this`, `super`, etc.)
-### **variable.parameter**
-Function parameters
-### **variable.other**
-Other variables
-### **variable.other.member**
-Fields of composite data types (e.g. structs, unions)
-### **variable.other.member.private**
-Private fields that use a unique syntax (currently just EMCAScript-based languages)
-### **label**
-Highlighting labels
-### **punctuation**
-Highlighting punctuation
-### **punctuation.delimiter**
-Commas, colon
-### **punctuation.bracket**
-Parentheses, angle brackets, etc.
-### **punctuation.special**
-String interpolation brackets
-### **keyword**
-Highlighting keywords
-### **keyword.control**
-Control keywords
-### **keyword.control.conditional**
-if, else
-### **keyword.control.repeat**
-for, while, loop
-### **keyword.control.import**
-import, export
-### **keyword.control.return**
-return keyword
-### **keyword.control.exception**
-exception keyword
-### **keyword.operator**
-or, in
-### **keyword.directive**
-Preprocessor directives (`#if` in C)
-### **keyword.function**
-fn, func
-### **keyword.storage**
-Keywords describing how things are stored
-### **keyword.storage.type**
-The type of something, `class`, `function`, `var`, `let`, etc
-### **keyword.storage.modifier**
-Storage modifiers like `static`, `mut`, `const`, `ref`, etc
-### **operator**
-Operators such as `||`, `+=`, `>`, etc
-### **function**
-Highlighting function calls
-### **function.builtin**
-Builtin functions
-### **function.method**
-Calling methods
-### **function.method.private**
-Private methods that use a unique syntax (currently just ECMAScript-based languages)
-### **function.macro**
-Highlighting macros
-### **function.special**
-Preprocessor in C
-### **tag**
-Tags (e.g. <body> in HTML)
-### **tag.builtin**
-Builtin tags
-### **markup**
-Highlighting markdown
-### **markup.heading**
-Markdown heading
-### **markup.heading.marker**
-Markdown heading marker
-### **markup.heading.marker.1**
-Markdown heading text h1
-### **markup.heading.marker.2**
-Markdown heading text h2
-### **markup.heading.marker.3**
-Markdown heading text h3
-### **markup.heading.marker.4**
-Markdown heading text h4
-### **markup.heading.marker.5**
-Markdown heading text h5
-### **markup.heading.marker.6**
-Markdown heading text h6
-### **markup.list**
-Markdown lists
-### **markup.list.unnumbered**
-Unnumbered markdown lists
-### **markup.list.numbered**
-Numbered markdown lists
-### **markup.list.checked**
-Checked markdown lists
-### **markup.list.unchecked**
-Unchecked markdown lists
-### **markup.bold**
-Markdown bold
-### **markup.italic**
-Markdown italics
-### **markup.strikethrough**
-Markdown strikethrough
-### **markup.link**
-Markdown links
-### **markup.link.url**
-URLs pointed to by links
-### **markup.link.label**
-non-URL link references
-### **markup.link.text**
-URL and image descriptions in links
-### **markup.quote**
-Markdown quotes
-### **markup.raw**
-Markdown raw
-### **markup.raw.inline**
-Markdown inline raw
-### **markup.raw.block**
-Markdown raw block
-### **diff**
-Version control changes
-### **diff.plus**
-Version control additions
-### **diff.plus.gutter**
-Version control addition gutter indicator
-### **diff.minus**
-Version control deletions
-### **diff.minus.gutter**
-Version control deletion gutter indicator
-### **diff.delta**
-Version control modifications
-### **diff.delta.moved**
-Renamed or moved files/changes
-### **diff.delta.conflict**
-Merge conflicts
-### **diff.delta.gutter**
-Gutter indicator
-### **markup.normal.completion**
-For completion doc popup UI
-### **markup.normal.hover**
-For hover popup UI
-### **markup.heading.completion**
-For completion doc popup UI
-### **markup.heading.hover**
-For hover popup UI
-### **markup.raw.inline.completion**
-For completion doc popup UI
-### **markup.raw.inline.hover**
-For hover popup UI
-### **ui.background.separator**
-Picker separator below input line
-### **ui.cursor.match**
-Matching bracket etc.
-### **ui.cursor.primary**
-Cursor with primary selection
-### **ui.debug.breakpoint**
-Breakpoint indicator, found in the gutter
-### **ui.debug.active**
-Indicator for the line at which debugging execution is paused at, found in the gutter
-### **ui.gutter**
-Gutter
-### **ui.gutter.selected**
-Gutter for the line the cursor is on
-### **ui.highlight.frameline**
-Line at which debugging execution is paused at
-### **ui.linenr**
-Line numbers
-### **ui.linenr.selected**
-Line number for the line the cursor is on
-### **ui.statusline**
-Statusline
-### **ui.statusline.inactive**
-Statusline (unfocused document)
-### **ui.statusline.normal**
-Statusline mode during normal mode (only if editor.color-modes is enabled)
-### **ui.statusline.insert**
-Statusline mode during insert mode (only if editor.color-modes is enabled)
-### **ui.statusline.select**
-Statusline mode during select mode (only if editor.color-modes is enabled)
-### **ui.statusline.separator**
-Separator character in statusline
-### **ui.bufferline**
-Style for the buffer line
-### **ui.bufferline.active**
-Style for the active buffer in buffer line
-### **ui.bufferline.background**
-Style for the bufferline background
-### **ui.popup**
-Documentation popups (e.g. Space + k)
-### **ui.popup.info**
-Prompt for multiple key options
-### **ui.window**
-Borderline separating splits
-### **ui.help**
-Description box for commands
-### **ui.text**
-Default text style, command prompts, popup text, etc.
-### **ui.text.focus**
-The currently selected line in the picker
-### **ui.text.inactive**
-Same as ui.text but when the text is inactive (e.g. suggestions)
-### **ui.text.info**
-The key: command text in ui.popup.info boxes
-### **ui.virtual.ruler**
-Ruler columns (see the editor.rules config)
-### **ui.virtual.whitespace**
-Visible whitespace characters
-### **ui.virtual.indent-guide**
-Vertical indent width guides
-### **ui.virtual.inlay-hint**
-Default style for inlay hints of all kinds
-### **ui.virtual.inlay-hint.parameter**
-Style for inlay hints of kind `parameter` (LSPs are not rquired to set a kind)
-### **ui.virtual.inlay-hint.type**
-Style for inlay hints of kind `type` (LSPs are not required to set a kind)
-### **ui.virtual.wrap**
-Soft-wrap indicator (see the editor.soft-wrap config)
-### **ui.virtual.jump-label**
-Style for virtual jump labels
-### **ui.menu**
-Code and command completion menus
-### **ui.menu.selected**
-Selected autocomplete item
-### **ui.menu.scroll**
-fg sets thumb color, bg sets track color of scrollbar
-### **ui.selection**
-For selections in the editing area
-### **ui.highlight**
-Highlighted lines in the picker preview
-### **ui.cursorline**
-The line of the cursor (if cursorline is enabled)
-### **ui.cursorline.primary**
-The line of the primary cursor (if cursorline is enabled)
-### **ui.cursorline.secondary**
-The line of the secondary cursor (if cursorline is enabled)
-### **ui.cursorcolumn.primary**
-The column of the primary cursor (if cursorcolumn is enabled)
-### **ui.cursorcolumn.secondary**
-The column of the secondary cursor (if cursorcolumn is enabled)
-### **warning**
-Diagnostics warning (gutter)
-### **error**
-Diagnostics error (gutter)
-### **info**
-Diagnostics info (gutter)
-### **hint**
-Diagnostics hint (gutter)
-### **diagnostic**
-Diagnostics fallback style (editing area)
-### **diagnostic.hint**
-Diagnostics hint (editing area)
-### **diagnostic.info**
-Diagnostics info (editing area)
-### **diagnostic.warning**
-Diagnostics warning (editing area)
-### **diagnostic.error**
-Diagnostics error (editing area)
-### **diagnostic.unnecessary**
-Diagnostics with unnecessary tag (editing area)
-### **diagnostic.deprecated**
-Diagnostics with deprecated tag (editing area)
-# /home/matt/.steel/cogs/helix/static.scm
+### **range->selection**
+Convert a range into a selection
+### **get-helix-scm-path**
+Returns the path to the helix.scm file as a string
+### **get-init-scm-path**
+Returns the path to the init.scm file as a string
 ### **no_op**
 Do nothing
 ### **move_char_left**
@@ -1607,11 +332,11 @@ Goto type definition
 ### **goto_implementation**
 Goto implementation
 ### **goto_file_start**
-Goto line number <n> else file start
+Goto line number `<n>` else file start
 ### **goto_file_end**
 Goto file end
 ### **extend_to_file_start**
-Extend to line number<n> else file start
+Extend to line number `<n>` else file start
 ### **extend_to_file_end**
 Extend to file end
 ### **goto_file**
@@ -1972,79 +697,7 @@ Goto next snippet placeholder
 Make the first selection your primary one
 ### **rotate_selections_last**
 Make the last selection your primary one
-### **insert_char**
-Insert a given character at the cursor cursor position
-### **insert_string**
-Insert a given string at the current cursor position
-### **set-current-selection-object!**
-Update the selection object to the current selection within the editor
-### **push-range-to-selection!**
-Push a new range to a selection. The new selection will be the primary one
-### **set-current-selection-primary-index!**
-Set the primary index of the current selection
-### **remove-current-selection-range!**
-Remove a range from the current selection
-### **regex-selection**
-Run the given regex within the existing buffer
-### **replace-selection-with**
-Replace the existing selection with the given string
-### **enqueue-expression-in-engine**
-Enqueue an expression to run at the top level context, 
-       after the existing function context has exited.
-### **get-current-line-character**
-Returns the current column number with the given position encoding
-### **cx->current-file**
-Get the currently focused file path
-### **current_selection**
-Returns the current selection as a string
-### **current-selection->string**
-Returns the current selection as a string
-### **load-buffer!**
-Evaluates the current buffer
-### **current-highlighted-text!**
-Returns the currently highlighted text as a string
-### **get-current-line-number**
-Returns the current line number
-### **get-current-column-number**
-Returns the visual current column number of unicode graphemes
-### **current-selection-object**
-Returns the current selection object
-### **get-helix-cwd**
-Returns the current working directly that helix is using
-### **move-window-far-left**
-Moves the current window to the far left
-### **move-window-far-right**
-Moves the current window to the far right
-### **selection->primary-index**
-Returns index of the primary selection
-### **selection->primary-range**
-Returns the range for primary selection
-### **selection->ranges**
-Returns all ranges of the selection
-### **range-anchor**
-Get the anchor of the range: the side that doesn't move when extending.
-### **range->from**
-Get the start of the range
-### **range-head**
-Get the head of the range, moved when extending.
-### **range->to**
-Get the end of the range
-### **range->span**
-Get the span of the range (from, to)
-### **range**
-Construct a new range object
-
-```scheme
-(range anchor head) -> Range?
-```
-       
-### **range->selection**
-Convert a range into a selection
-### **get-helix-scm-path**
-Returns the path to the helix.scm file as a string
-### **get-init-scm-path**
-Returns the path to the init.scm file as a string
-# /home/matt/.steel/cogs/helix/ext.scm
+# /home/roastbeefer/.local/share/steel/cogs/helix/ext.scm
 ### **eval-buffer**
 Eval the current buffer, morally equivalent to load-buffer!
 ### **evalp**
@@ -2065,7 +718,7 @@ thunk : (-> any?) ;; Function that has no arguments
 # Examples
 ```scheme
 (spawn-native-thread
-  (lambda () 
+  (lambda ()
     (hx.with-context (lambda () (theme "nord")))))
 ```
 ### **hx.block-on-task**
@@ -2079,7 +732,7 @@ thunk : (-> any?) ;; Function that has no arguments
 ```scheme
 (define thread
   (spawn-native-thread
-    (lambda () 
+    (lambda ()
       (hx.block-on-task (lambda () (theme "nord") 10)))))
 
 ;; Some time later, in a different context - if done at the same time,
@@ -2087,13 +740,398 @@ thunk : (-> any?) ;; Function that has no arguments
 ;; executing.
 (equal? (thread-join! thread) 10) ;; => #true
 ```
-# /home/matt/.steel/cogs/helix/components.scm
+# /home/roastbeefer/.local/share/steel/cogs/helix/themes.scm
+### **register-theme**
+Register this theme with helix for use
+### **get-theme-by-name**
+Fetch a theme by name. Returns #false if the theme does not exist
+### **attribute**
+Class attributes, HTML tag attributes
+### **type**
+Types
+### **type.builtin**
+Primitive types provided by the language (`int`, `usize`)
+### **type.parameter**
+Generic type parameters (`T`)
+### **type.enum**
+Enum usage
+### **type.enum.variant**
+Enum variant
+### **constructor**
+Constructor usage
+### **constant**
+Constants usage
+### **constant.builtin**
+Special constants provided by the language (`true`, `false`, `nil`, etc)
+### **constant.builtin.boolean**
+A special case for highlighting individual booleans
+### **constant.character**
+Character usage
+### **constant.character.escape**
+Highlighting individual escape characters
+### **constant.numeric**
+Numbers
+### **constant.numeric.integer**
+Integers
+### **constant.numeric.float**
+Floats
+### **string**
+Highlighting strings
+### **string.regexp**
+Highlighting regular expressions
+### **string.special**
+Special strings
+### **string.special.path**
+Highlighting paths
+### **string.special.url**
+Highlighting URLs
+### **string.special.symbol**
+Erlang/Elixir atoms, Ruby symbols, Clojure keywords
+### **comment**
+Highlighting comments
+### **comment.line**
+Single line comments (`//`)
+### **comment.block**
+Block comments (`/* */`)
+### **comment.block.documentation**
+Documentation comments (e.g. `///` in Rust)
+### **variable**
+Variables
+### **variable.builtin**
+Reserved language variables (`self`, `this`, `super`, etc.)
+### **variable.parameter**
+Function parameters
+### **variable.other**
+Other variables
+### **variable.other.member**
+Fields of composite data types (e.g. structs, unions)
+### **variable.other.member.private**
+Private fields that use a unique syntax (currently just EMCAScript-based languages)
+### **label**
+Highlighting labels
+### **punctuation**
+Highlighting punctuation
+### **punctuation.delimiter**
+Commas, colon
+### **punctuation.bracket**
+Parentheses, angle brackets, etc.
+### **punctuation.special**
+String interpolation brackets
+### **keyword**
+Highlighting keywords
+### **keyword.control**
+Control keywords
+### **keyword.control.conditional**
+if, else
+### **keyword.control.repeat**
+for, while, loop
+### **keyword.control.import**
+import, export
+### **keyword.control.return**
+return keyword
+### **keyword.control.exception**
+exception keyword
+### **keyword.operator**
+or, in
+### **keyword.directive**
+Preprocessor directives (`#if` in C)
+### **keyword.function**
+fn, func
+### **keyword.storage**
+Keywords describing how things are stored
+### **keyword.storage.type**
+The type of something, `class`, `function`, `var`, `let`, etc
+### **keyword.storage.modifier**
+Storage modifiers like `static`, `mut`, `const`, `ref`, etc
+### **operator**
+Operators such as `||`, `+=`, `>`, etc
+### **function**
+Highlighting function calls
+### **function.builtin**
+Builtin functions
+### **function.method**
+Calling methods
+### **function.method.private**
+Private methods that use a unique syntax (currently just ECMAScript-based languages)
+### **function.macro**
+Highlighting macros
+### **function.special**
+Preprocessor in C
+### **tag**
+Tags (e.g. <body> in HTML)
+### **tag.builtin**
+Builtin tags
+### **markup**
+Highlighting markdown
+### **markup.heading**
+Markdown heading
+### **markup.heading.marker**
+Markdown heading marker
+### **markup.heading.marker.1**
+Markdown heading text h1
+### **markup.heading.marker.2**
+Markdown heading text h2
+### **markup.heading.marker.3**
+Markdown heading text h3
+### **markup.heading.marker.4**
+Markdown heading text h4
+### **markup.heading.marker.5**
+Markdown heading text h5
+### **markup.heading.marker.6**
+Markdown heading text h6
+### **markup.list**
+Markdown lists
+### **markup.list.unnumbered**
+Unnumbered markdown lists
+### **markup.list.numbered**
+Numbered markdown lists
+### **markup.list.checked**
+Checked markdown lists
+### **markup.list.unchecked**
+Unchecked markdown lists
+### **markup.bold**
+Markdown bold
+### **markup.italic**
+Markdown italics
+### **markup.strikethrough**
+Markdown strikethrough
+### **markup.link**
+Markdown links
+### **markup.link.url**
+URLs pointed to by links
+### **markup.link.label**
+non-URL link references
+### **markup.link.text**
+URL and image descriptions in links
+### **markup.quote**
+Markdown quotes
+### **markup.raw**
+Markdown raw
+### **markup.raw.inline**
+Markdown inline raw
+### **markup.raw.block**
+Markdown raw block
+### **diff**
+Version control changes
+### **diff.plus**
+Version control additions
+### **diff.plus.gutter**
+Version control addition gutter indicator
+### **diff.minus**
+Version control deletions
+### **diff.minus.gutter**
+Version control deletion gutter indicator
+### **diff.delta**
+Version control modifications
+### **diff.delta.moved**
+Renamed or moved files/changes
+### **diff.delta.conflict**
+Merge conflicts
+### **diff.delta.gutter**
+Gutter indicator
+### **markup.normal.completion**
+For completion doc popup UI
+### **markup.normal.hover**
+For hover popup UI
+### **markup.heading.completion**
+For completion doc popup UI
+### **markup.heading.hover**
+For hover popup UI
+### **markup.raw.inline.completion**
+For completion doc popup UI
+### **markup.raw.inline.hover**
+For hover popup UI
+### **ui.background.separator**
+Picker separator below input line
+### **ui.cursor.match**
+Matching bracket etc.
+### **ui.cursor.primary**
+Cursor with primary selection
+### **ui.debug.breakpoint**
+Breakpoint indicator, found in the gutter
+### **ui.debug.active**
+Indicator for the line at which debugging execution is paused at, found in the gutter
+### **ui.gutter**
+Gutter
+### **ui.gutter.selected**
+Gutter for the line the cursor is on
+### **ui.highlight.frameline**
+Line at which debugging execution is paused at
+### **ui.linenr**
+Line numbers
+### **ui.linenr.selected**
+Line number for the line the cursor is on
+### **ui.statusline**
+Statusline
+### **ui.statusline.inactive**
+Statusline (unfocused document)
+### **ui.statusline.normal**
+Statusline mode during normal mode (only if editor.color-modes is enabled)
+### **ui.statusline.insert**
+Statusline mode during insert mode (only if editor.color-modes is enabled)
+### **ui.statusline.select**
+Statusline mode during select mode (only if editor.color-modes is enabled)
+### **ui.statusline.separator**
+Separator character in statusline
+### **ui.bufferline**
+Style for the buffer line
+### **ui.bufferline.active**
+Style for the active buffer in buffer line
+### **ui.bufferline.background**
+Style for the bufferline background
+### **ui.popup**
+Documentation popups (e.g. Space + k)
+### **ui.popup.info**
+Prompt for multiple key options
+### **ui.window**
+Borderline separating splits
+### **ui.help**
+Description box for commands
+### **ui.text**
+Default text style, command prompts, popup text, etc.
+### **ui.text.directory**
+Directory names in prompt completion
+### **ui.text.focus**
+The currently selected line in the picker
+### **ui.text.inactive**
+Same as ui.text but when the text is inactive (e.g. suggestions)
+### **ui.text.info**
+The key: command text in ui.popup.info boxes
+### **ui.virtual.ruler**
+Ruler columns (see the editor.rules config)
+### **ui.virtual.whitespace**
+Visible whitespace characters
+### **ui.virtual.indent-guide**
+Vertical indent width guides
+### **ui.virtual.inlay-hint**
+Default style for inlay hints of all kinds
+### **ui.virtual.inlay-hint.parameter**
+Style for inlay hints of kind `parameter` (LSPs are not rquired to set a kind)
+### **ui.virtual.inlay-hint.type**
+Style for inlay hints of kind `type` (LSPs are not required to set a kind)
+### **ui.virtual.wrap**
+Soft-wrap indicator (see the editor.soft-wrap config)
+### **ui.virtual.jump-label**
+Style for virtual jump labels
+### **ui.menu**
+Code and command completion menus
+### **ui.menu.selected**
+Selected autocomplete item
+### **ui.menu.scroll**
+fg sets thumb color, bg sets track color of scrollbar
+### **ui.selection**
+For selections in the editing area
+### **ui.highlight**
+Highlighted lines in the picker preview
+### **ui.cursorline**
+The line of the cursor (if cursorline is enabled)
+### **ui.cursorline.primary**
+The line of the primary cursor (if cursorline is enabled)
+### **ui.cursorline.secondary**
+The line of the secondary cursor (if cursorline is enabled)
+### **ui.cursorcolumn.primary**
+The column of the primary cursor (if cursorcolumn is enabled)
+### **ui.cursorcolumn.secondary**
+The column of the secondary cursor (if cursorcolumn is enabled)
+### **warning**
+Diagnostics warning (gutter)
+### **error**
+Diagnostics error (gutter)
+### **info**
+Diagnostics info (gutter)
+### **hint**
+Diagnostics hint (gutter)
+### **diagnostic**
+Diagnostics fallback style (editing area)
+### **diagnostic.hint**
+Diagnostics hint (editing area)
+### **diagnostic.info**
+Diagnostics info (editing area)
+### **diagnostic.warning**
+Diagnostics warning (editing area)
+### **diagnostic.error**
+Diagnostics error (editing area)
+### **diagnostic.unnecessary**
+Diagnostics with unnecessary tag (editing area)
+### **diagnostic.deprecated**
+Diagnostics with deprecated tag (editing area)
+# /home/roastbeefer/.local/share/steel/cogs/helix/components.scm
+### **StatusElement?**
+Check if the provided value is a `StatusElement`
+### **status-element**
+Create a new status element with a closure that returns an ordered list of styled `Span`s to be added to be rendered by the status bar
+```scm
+(status-element fun) -> StatusElement?
+```
+* fun: (-> DocumentID? bool?) -> (listof Span?)
+### **Span?**
+Check if the provided value is a `Span`
+### **span**
+Create a span with the given contents and style
+
+```scm
+(span content style) -> Span?
+```
+* content: string?
+* style: Style?
+### **span-content**
+Create a span with the given contents and style
+
+```scm
+(span-content span) -> string?
+```
+* span: Span?
+### **span-style**
+Create a span with the given styles and style
+
+```scm
+(span-style span) -> Style?
+```
+* span: Span?
+### **push-status-element!**
+Push a status element to a given side in the statusbar
+`side` can be:
+   * 'left
+   * 'right
+   * 'center
+```scm
+(push-status-element! side elem)
+```
+
+* side: symbol?
+* elem: StatusElement?
 ### **theme->bg**
+DEPRECATED: Please use `theme-scope`
 Gets the `Style` associated with the bg for the current theme
 ### **theme->fg**
+DEPRECATED: Please use `theme-scope`
 Gets the `style` associated with the fg for the current theme
-### **theme-scope**
+### **theme-scope-ref**
 Get the `Style` associated with the given scope from the current theme
+```
+(theme-scope-ref scope)
+```
+scope : string?
+
+# Examples
+
+```scheme
+(theme-scope-ref "ui.text")
+```
+### **theme-scope**
+Note: Prefer using theme-scope-ref. This is left in for backwards compatibility.
+
+Get the `Style` associated with the given scope from the current theme
+```
+(theme-scope scope)
+```
+scope : string?
+
+# Examples
+
+```scheme
+(theme-scope "ui.text")
+```
 ### **Position?**
 Check if the given value is a `Position`
 
@@ -2103,7 +1141,7 @@ Check if the given value is a `Position`
 
 value : any?
 
-       
+
 ### **Style?**
 Check if the given valuie is `Style`
 
@@ -2121,7 +1159,7 @@ Checks if the given value is a `Buffer`
 ```
 
 value : any?
-       
+
 ### **buffer-area**
 
 Get the `Rect` associated with the given `Buffer`
@@ -2131,7 +1169,7 @@ Get the `Rect` associated with the given `Buffer`
 ```
 
 * buffer : Buffer?
-       
+
 ### **frame-set-string!**
 
 Set the string at the given `x` and `y` positions for the given `Buffer`, with a provided `Style`.
@@ -2145,7 +1183,7 @@ x : int?,
 y : int?,
 string: string?,
 style: Style?,
-       
+
 ### **SteelEventResult?**
 
 Check whether the given value is a `SteelEventResult`.
@@ -2156,7 +1194,7 @@ Check whether the given value is a `SteelEventResult`.
 
 value : any?
 
-       
+
 ### **new-component!**
 
 Construct a new dynamic component. This is used for creating widgets or floating windows
@@ -2187,15 +1225,15 @@ function-map : (hashof string? function?)
        * event-result/close
 
        See the associated docs for those to understand the implications for each.
-       
+
    "cursor" : (-> state? Rect?) -> Position?
 
        This tells helix where to put the cursor.
-   
+
    "required_size": (-> state? (pair? int?)) -> (pair? int?)
 
        Seldom used: TODO
-   
+
 ### **position**
 
 Construct a new `Position`.
@@ -2206,7 +1244,7 @@ Construct a new `Position`.
 
 row : int?
 col : int?
-       
+
 ### **position-row**
 
 Get the row associated with the given `Position`.
@@ -2216,7 +1254,7 @@ Get the row associated with the given `Position`.
 ```
 
 pos : `Position?`
-       
+
 ### **position-col**
 
 Get the col associated with the given `Position`.
@@ -2235,7 +1273,7 @@ Set the row for the given `Position`
 
 pos : Position?
 row : int?
-       
+
 ### **set-position-col!**
 Set the col for the given `Position`
 
@@ -2245,7 +1283,7 @@ Set the col for the given `Position`
 
 pos : Position?
 col : int?
-       
+
 ### **Rect?**
 Check if the given value is a `Rect`
 
@@ -2255,7 +1293,7 @@ Check if the given value is a `Rect`
 
 value : any?
 
-       
+
 ### **area**
 
 Constructs a new `Rect`.
@@ -2280,7 +1318,7 @@ Get the `x` value of the given `Rect`
 ```
 
 area : Rect?
-       
+
 ### **area-y**
 Get the `y` value of the given `Rect`
 
@@ -2289,7 +1327,7 @@ Get the `y` value of the given `Rect`
 ```
 
 area : Rect?
-       
+
 ### **area-width**
 Get the `width` value of the given `Rect`
 
@@ -2298,7 +1336,7 @@ Get the `width` value of the given `Rect`
 ```
 
 area : Rect?
-       
+
 ### **area-height**
 Get the `height` value of the given `Rect`
 
@@ -2307,7 +1345,14 @@ Get the `height` value of the given `Rect`
 ```
 
 area : Rect?
-       
+
+### **render-native-component**
+Render a native component
+### **markdown-component**
+Render a native component
+```
+(markdown-component text)
+```
 ### **Widget/list?**
 Check whether the given value is a list widget.
 
@@ -2316,7 +1361,7 @@ Check whether the given value is a list widget.
 ```
 
 value : any?
-       
+
 ### **widget/list**
 Creates a new `List` widget with the given items.
 
@@ -2325,7 +1370,7 @@ Creates a new `List` widget with the given items.
 ```
 
 * lst : (listof string?)
-       
+
 ### **widget/list/render**
 
 
@@ -2338,7 +1383,7 @@ Render the given `Widget/list` onto the provided `Rect` within the given `Buffer
 * buf : `Buffer?`
 * area : `Rect?`
 * lst : `Widget/list?`
-       
+
 ### **block**
 Creates a block with the following styling:
 
@@ -2350,7 +1395,7 @@ Creates a block with the following styling:
 * border-style - default style + white fg
 * border-type - rounded
 * style - default + black bg
-       
+
 ### **make-block**
 
 Create a `Block` with the provided styling, borders, and border type.
@@ -2377,7 +1422,7 @@ Valid borders include:
 * "right"
 * "bottom"
 * "all"
-       
+
 ### **block/render**
 
 Render the given `Block` over the given `Rect` onto the provided `Buffer`.
@@ -2389,27 +1434,27 @@ Render the given `Block` over the given `Rect` onto the provided `Buffer`.
 buf : Buffer?
 area: Rect?
 block: Block?
-           
-       
+
+
 ### **buffer/clear**
 Clear a `Rect` in the `Buffer`
 
 ```scheme
-(buffer/clear area)
+(buffer/clear frame area)
 ```
-
+frame : Buffer?
 area : Rect?
-       
+
 ### **buffer/clear-with**
 Clear a `Rect` in the `Buffer` with a default `Style`
 
 ```scheme
-(buffer/clear-with area style)
+(buffer/clear-with frame area style)
 ```
-
+frame : Buffer?
 area : Rect?
 style : Style?
-       
+
 ### **set-color-rgb!**
 
 Mutate the r/g/b of a color in place, to avoid allocation.
@@ -2432,7 +1477,7 @@ Mutate this color to be an indexed color.
 
 color : Color?
 index: int?
-   
+
 ### **Color?**
 Check if the given value is a `Color`.
 
@@ -2442,75 +1487,75 @@ Check if the given value is a `Color`.
 
 value : any?
 
-       
+
 ### **Color/Reset**
 
 Singleton for the reset color.
-       
+
 ### **Color/Black**
 
 Singleton for the color black.
-       
+
 ### **Color/Red**
 
 Singleton for the color red.
-       
+
 ### **Color/White**
 
 Singleton for the color white.
-       
+
 ### **Color/Green**
 
 Singleton for the color green.
-       
+
 ### **Color/Yellow**
 
 Singleton for the color yellow.
-       
+
 ### **Color/Blue**
 
 Singleton for the color blue.
-       
+
 ### **Color/Magenta**
 
 Singleton for the color magenta.
-       
+
 ### **Color/Cyan**
 
 Singleton for the color cyan.
-       
+
 ### **Color/Gray**
 
 Singleton for the color gray.
-       
+
 ### **Color/LightRed**
 
 Singleton for the color light read.
-       
+
 ### **Color/LightGreen**
 
 Singleton for the color light green.
-       
+
 ### **Color/LightYellow**
 
 Singleton for the color light yellow.
-       
+
 ### **Color/LightBlue**
 
 Singleton for the color light blue.
-       
+
 ### **Color/LightMagenta**
 
 Singleton for the color light magenta.
-       
+
 ### **Color/LightCyan**
 
 Singleton for the color light cyan.
-       
+
 ### **Color/LightGray**
 
 Singleton for the color light gray.
-       
+
 ### **Color/rgb**
 
 Construct a new color via rgb.
@@ -2522,7 +1567,7 @@ Construct a new color via rgb.
 r : int?
 g : int?
 b : int?
-       
+
 ### **Color-red**
 
 Get the red component of the `Color?`.
@@ -2532,7 +1577,7 @@ Get the red component of the `Color?`.
 ```
 
 color * Color?
-       
+
 ### **Color-green**
 
 Get the green component of the `Color?`.
@@ -2561,7 +1606,7 @@ Construct a new indexed color.
 ```
 
 * index : int?
-       
+
 ### **set-style-fg!**
 
 
@@ -2573,7 +1618,7 @@ Mutates the given `Style` to have the fg with the provided color.
 
 style : `Style?`
 color : `Color?`
-       
+
 ### **style-fg**
 
 
@@ -2585,7 +1630,7 @@ Constructs a new `Style` with the provided `Color` for the fg.
 
 style : Style?
 color: Color?
-       
+
 ### **style-bg**
 
 
@@ -2597,7 +1642,7 @@ Constructs a new `Style` with the provided `Color` for the bg.
 
 style : Style?
 color: Color?
-       
+
 ### **style-with-italics**
 
 
@@ -2608,7 +1653,7 @@ Constructs a new `Style` with italcs.
 ```
 
 style : Style?
-       
+
 ### **style-with-bold**
 
 
@@ -2619,7 +1664,7 @@ Constructs a new `Style` with bold styling.
 ```
 
 style : Style?
-       
+
 ### **style-with-dim**
 
 
@@ -2630,7 +1675,7 @@ Constructs a new `Style` with dim styling.
 ```
 
 style : Style?
-       
+
 ### **style-with-slow-blink**
 
 
@@ -2641,7 +1686,7 @@ Constructs a new `Style` with slow blink.
 ```
 
 style : Style?
-       
+
 ### **style-with-rapid-blink**
 
 
@@ -2652,7 +1697,7 @@ Constructs a new `Style` with rapid blink.
 ```
 
 style : Style?
-       
+
 ### **style-with-reversed**
 
 
@@ -2663,7 +1708,7 @@ Constructs a new `Style` with revered styling.
 ```
 
 style : Style?
-       
+
 ### **style-with-hidden**
 
 Constructs a new `Style` with hidden styling.
@@ -2673,7 +1718,7 @@ Constructs a new `Style` with hidden styling.
 ```
 
 style : Style?
-       
+
 ### **style-with-crossed-out**
 
 
@@ -2684,7 +1729,7 @@ Constructs a new `Style` with crossed out styling.
 ```
 
 style : Style?
-       
+
 ### **style->fg**
 
 
@@ -2695,8 +1740,8 @@ Return the color on the style, or #false if not present.
 ```
 
 style : Style?
-           
-       
+
+
 ### **style->bg**
 
 
@@ -2707,8 +1752,8 @@ Return the color on the style, or #false if not present.
 ```
 
 style : Style?
-           
-       
+
+
 ### **set-style-bg!**
 
 
@@ -2720,8 +1765,8 @@ Mutate the background style on the given style to a given color.
 
 style : Style?
 color : Color?
-           
-       
+
+
 ### **style-underline-color**
 
 
@@ -2733,8 +1778,8 @@ Return a new style with the provided underline color.
 ```
 style : Style?
 color : Color?
-           
-       
+
+
 ### **style-underline-style**
 
 Return a new style with the provided underline style.
@@ -2759,57 +1804,57 @@ value : any?
 ### **Underline/Reset**
 
 Singleton for resetting the underling style.
-       
+
 ### **Underline/Line**
 
 Singleton for the line underline style.
-       
+
 ### **Underline/Curl**
 
 Singleton for the curl underline style.
-       
+
 ### **Underline/Dotted**
 
 Singleton for the dotted underline style.
-       
+
 ### **Underline/Dashed**
 
 Singleton for the dashed underline style.
-       
+
 ### **Underline/DoubleLine**
 
 Singleton for the double line underline style.
-       
+
 ### **event-result/consume**
 
 Singleton for consuming an event. If this is returned from an event handler, the event
 will not continue to be propagated down the component stack. This also will trigger a
 re-render.
-       
+
 ### **event-result/consume-without-rerender**
 
 Singleton for consuming an event. If this is returned from an event handler, the event
 will not continue to be propagated down the component stack. This will _not_ trigger
 a re-render.
-       
+
 ### **event-result/ignore**
 
 Singleton for ignoring an event. If this is returned from an event handler, the event
 will not continue to be propagated down the component stack. This will _not_ trigger
 a re-render.
-       
+
 ### **event-result/ignore-and-close**
 
 Singleton for ignoring an event. If this is returned from an event handler, the event
 will continue to be propagated down the component stack, and the component will be
 popped off of the stack and removed.
-       
+
 ### **event-result/close**
 
 Singleton for consuming an event. If this is returned from an event handler, the event
 will not continue to be propagated down the component stack, and the component will
 be popped off of the stack and removed.
-       
+
 ### **style**
 
 Constructs a new default style.
@@ -2817,7 +1862,7 @@ Constructs a new default style.
 ```scheme
 (style) -> Style?
 ```
-       
+
 ### **Event?**
 Check if this value is an `Event`
 
@@ -2825,7 +1870,25 @@ Check if this value is an `Event`
 (Event? value) -> bool?
 ```
 value : any?
-       
+
+### **focus-gained-event?**
+Checks if the given event is a focus gained event.
+
+```scheme
+(focus-gained-event? event) -> bool?
+```
+
+* event : Event?
+
+### **focus-lost-event?**
+Checks if the given event is a focus lost event.
+
+```scheme
+(focus-lost-event? event) -> bool?
+```
+
+* event : Event?
+
 ### **paste-event?**
 Checks if the given event is a paste event.
 
@@ -2834,8 +1897,8 @@ Checks if the given event is a paste event.
 ```
 
 * event : Event?
-           
-       
+
+
 ### **paste-event-string**
 Get the string from the paste event, if it is a paste event.
 
@@ -2845,7 +1908,7 @@ Get the string from the paste event, if it is a paste event.
 
 * event : Event?
 
-       
+
 ### **key-event?**
 Checks if the given event is a key event.
 
@@ -2854,7 +1917,7 @@ Checks if the given event is a key event.
 ```
 
 * event : Event?
-       
+
 ### **string->key-event**
 Get a key event from a string
 ### **event->key-event**
@@ -2866,7 +1929,15 @@ Get the character off of the event, if there is one.
 (key-event-char event) -> (or char? #false)
 ```
 event : Event?
-       
+
+### **on-key-event-char**
+Get the character off of the key event, if there is one.
+
+```scheme
+(on-key-event-char event) -> (or char? #false)
+```
+event : KeyEvent?
+
 ### **key-event-modifier**
 
 Get the key event modifier off of the event, if there is one.
@@ -2875,23 +1946,23 @@ Get the key event modifier off of the event, if there is one.
 (key-event-modifier event) -> (or int? #false)
 ```
 event : Event?
-       
+
 ### **key-modifier-ctrl**
 
 The key modifier bits associated with the ctrl key modifier.
-       
+
 ### **key-modifier-shift**
 
 The key modifier bits associated with the shift key modifier.
-       
+
 ### **key-modifier-alt**
 
 The key modifier bits associated with the alt key modifier.
-       
+
 ### **key-modifier-super**
 
 The key modifier bits associated with the super key modifier.
-       
+
 ### **key-event-F?**
 Check if this key event is associated with an `F<x>` key, e.g. F1, F2, etc.
 
@@ -2900,7 +1971,7 @@ Check if this key event is associated with an `F<x>` key, e.g. F1, F2, etc.
 ```
 event : Event?
 number : int?
-       
+
 ### **mouse-event?**
 
 Check if this event is a mouse event.
@@ -2950,8 +2021,8 @@ Get the row from the mouse event, of #false if it isn't a mouse event.
 ```
 
 event : Event?
-           
-       
+
+
 ### **event-mouse-col**
 
 
@@ -2962,7 +2033,7 @@ Get the col from the mouse event, of #false if it isn't a mouse event.
 ```
 
 event : Event?
-       
+
 ### **mouse-event-within-area?**
 Check whether the given mouse event occurred within a given `Rect`.
 
@@ -2972,7 +2043,7 @@ Check whether the given mouse event occurred within a given `Rect`.
 
 event : Event?
 area : Rect?
-       
+
 ### **key-event-escape?**
 
 Check whether the given event is the key: escape
@@ -3149,6 +2220,1470 @@ Check whether the given event is the key: keypad-begin
 (key-event-keypad-begin? event)
 ```
 event: Event?
+# /home/roastbeefer/.local/share/steel/cogs/helix/editor.scm
+### **register-hook**
+Register a hook to be called after the event kind fired. It is not possible
+to unregister a hook once it has been registered. Any values that are captured
+through the callback function for this hook are considered to be rooted,
+and will not be freed for the duration of the runtime.
+
+```scheme
+(register-hook event-kind callback-fn)
+
+event-kind - symbol?
+callback-fn - function?
+```
+
+The valid events are as follows:
+* 'on-mode-switch
+* 'post-insert-char
+* 'post-command
+* 'terminal-focus-gained
+* 'terminal-focus-lost
+* 'document-focus-lost
+* 'selection-did-change
+* 'document-opened
+* 'document-saved
+* 'document-changed
+* 'document-closed
+
+Each of these expects a function with a slightly different signature to accept
+the event payload.
+
+## on-mode-switch
+
+Expects a function with one argument to accept the `OnModeSwitchEvent`.
+
+### Example:
+```scheme
+(register-hook 'on-mode-switch (lambda (switch-event) (log::info! (mode-switch-old switch-event))))
+```
+
+## post-insert-char
+
+Expects a function with one argument to accept the character (`char?`).
+
+```scheme
+(register-hook 'post-insert-char
+         (lambda (char) (log::info! char)))
+```
+
+## post-command
+
+Post command expects a function with one argument to accept the name of the command that was called.
+Note, this does not provide the arguments for the command, just the name of the command.
+
+```scheme
+(register-hook 'post-command
+               (lambda (command-name) (log::info! command-name)))
+```
+
+## terminal-focus-gained
+
+Expects a function with no arguments.
+
+```scheme
+(register-hook 'terminal-focus-gained
+               (lambda () (log::info! "terminal focus gained")))
+```
+
+## terminal-focus-lost
+
+Expects a function with no arguments.
+
+```scheme
+(register-hook 'terminal-focus-lost
+               (lambda () (log::info! "terminal focus lost")))
+```
+
+## document-focus-lost
+
+Expects a function with one argument to accept the doc id of the document that has lost focus.
+
+## selection-did-change
+
+Expects a function with one argument to accept the view id.
+
+## document-opened
+
+Expects a function with one argument to accept the doc id of the document that was just opened.
+
+## document-saved
+
+Expects a function with one argument to accept the doc id of the document that was just saved.
+## document-changed
+
+Expects a function with two arguments to accept the doc id of the docuoment that was just saved and the old text of the document before the change.
+## document-closed
+
+Expects a function with one argument to accept the `OnDocClosedEvent`
+### Example:
+```scheme
+(register-hook 'document-closed (lambda (closed-event) (log::info! (doc-closed-id closed-event))))
+### **editor-focus**
+
+Get the current focus of the editor, as a `ViewId`.
+
+```scheme
+(editor-focus) -> ViewId
+```
+
+### **editor-mode**
+
+Get the current mode of the editor
+
+```scheme
+(editor-mode) -> Mode?
+```
+
+### **cx->themes**
+DEPRECATED: Please use `themes->list`
+### **editor-count**
+Get the count
+### **themes->list**
+
+Get the current themes as a list of strings.
+
+```scheme
+(themes->list) -> (listof string?)
+```
+
+### **editor-all-documents**
+
+Get a list of all of the document ids that are currently open.
+
+```scheme
+(editor-all-documents) -> (listof DocumentId?)
+```
+
+### **cx->cursor**
+DEPRECATED: Please use `current-cursor`
+### **current-cursor**
+Gets the primary cursor position in screen coordinates,
+or `#false` if the primary cursor is not visible on screen.
+
+```scheme
+(current-cursor) -> (listof? (or Position? #false) CursorKind)
+```
+
+### **editor-focused-buffer-area**
+
+Get the `Rect` associated with the currently focused buffer.
+
+```scheme
+(editor-focused-buffer-area) -> (or Rect? #false)
+```
+
+### **selected-register!**
+Get currently selected register
+### **set-editor-count!**
+Sets the editor count.
+### **string->editor-mode**
+
+Create an editor mode from a string, or false if it string was not one of
+"normal", "insert", or "select"
+
+```scheme
+(string->editor-mode "normal") -> (or Mode? #f)
+```
+
+### **editor->doc-id**
+Get the document from a given view.
+### **editor-switch!**
+Open the document in a vertical split.
+### **editor-set-focus!**
+Set focus on the view.
+### **editor-set-mode!**
+Set the editor mode.
+### **editor-doc-in-view?**
+Check whether the current view contains a document.
+### **set-scratch-buffer-name!**
+Set the name of a scratch buffer.
+### **set-buffer-uri!**
+Set the URI of the buffer
+### **editor-doc-exists?**
+Check if a document exists.
+### **editor-document-last-saved**
+Check when a document was last saved (returns a `SystemTime`)
+### **editor-document->language**
+Get the language for the document
+### **editor-document-dirty?**
+Check if a document has unsaved changes
+### **editor-document-reload**
+Reload a document.
+### **editor->text**
+Get the document as a rope.
+### **editor-document->path**
+Get the path to a document.
+### **register->value**
+Get register value as a list of strings.
+### **set-editor-clip-top!**
+Set the editor clipping at the top.
+### **set-editor-clip-right!**
+Set the editor clipping at the right.
+### **set-editor-clip-left!**
+Set the editor clipping at the left.
+### **set-editor-clip-bottom!**
+Set the editor clipping at the bottom.
+# /home/roastbeefer/.local/share/steel/cogs/helix/commands.scm
+### **goto-column**
+Move the cursor to the given character index within the same line
+### **goto-line**
+Move the cursor to the given line
+### **exit**
+Write changes to disk if the buffer is modified and then quit. Accepts an optional path (:exit some/path.txt).
+### **exit!**
+Force write changes to disk, creating necessary subdirectories, if the buffer is modified and then quit. Accepts an optional path (:exit! some/path.txt).
+### **quit**
+Close the current view.
+### **quit!**
+Force close the current view, ignoring unsaved changes.
+### **open**
+Open a file from disk into the current view.
+### **buffer-close**
+Close the current buffer.
+### **buffer-close!**
+Close the current buffer forcefully, ignoring unsaved changes.
+### **buffer-close-others**
+Close all buffers but the currently focused one.
+### **buffer-close-others!**
+Force close all buffers but the currently focused one.
+### **buffer-close-all**
+Close all buffers without quitting.
+### **buffer-close-all!**
+Force close all buffers ignoring unsaved changes without quitting.
+### **buffer-next**
+Goto next buffer.
+### **buffer-previous**
+Goto previous buffer.
+### **write**
+Write changes to disk. Accepts an optional path (:write some/path.txt)
+### **write!**
+Force write changes to disk creating necessary subdirectories. Accepts an optional path (:write! some/path.txt)
+### **write-buffer-close**
+Write changes to disk and closes the buffer. Accepts an optional path (:write-buffer-close some/path.txt)
+### **write-buffer-close!**
+Force write changes to disk creating necessary subdirectories and closes the buffer. Accepts an optional path (:write-buffer-close! some/path.txt)
+### **new**
+Create a new scratch buffer.
+### **format**
+Format the file using an external formatter or language server.
+### **indent-style**
+Set the indentation style for editing. ('t' for tabs or 1-16 for number of spaces.)
+### **line-ending**
+Set the document's default line ending. Options: crlf, lf.
+### **earlier**
+Jump back to an earlier point in edit history. Accepts a number of steps or a time span.
+### **later**
+Jump to a later point in edit history. Accepts a number of steps or a time span.
+### **write-quit**
+Write changes to disk and close the current view. Accepts an optional path (:wq some/path.txt)
+### **write-quit!**
+Write changes to disk and close the current view forcefully. Accepts an optional path (:wq! some/path.txt)
+### **write-all**
+Write changes from all buffers to disk.
+### **write-all!**
+Forcefully write changes from all buffers to disk creating necessary subdirectories.
+### **write-quit-all**
+Write changes from all buffers to disk and close all views.
+### **write-quit-all!**
+Forcefully write changes from all buffers to disk, creating necessary subdirectories, and close all views (ignoring unsaved changes).
+### **quit-all**
+Close all views.
+### **quit-all!**
+Force close all views ignoring unsaved changes.
+### **cquit**
+Quit with exit code (default 1). Accepts an optional integer exit code (:cq 2).
+### **cquit!**
+Force quit with exit code (default 1) ignoring unsaved changes. Accepts an optional integer exit code (:cq! 2).
+### **theme**
+Change the editor theme (show current theme if no name specified).
+### **yank-join**
+Yank joined selections. A separator can be provided as first argument. Default value is newline.
+### **clipboard-yank**
+Yank main selection into system clipboard.
+### **clipboard-yank-join**
+Yank joined selections into system clipboard. A separator can be provided as first argument. Default value is newline.
+### **primary-clipboard-yank**
+Yank main selection into system primary clipboard.
+### **primary-clipboard-yank-join**
+Yank joined selections into system primary clipboard. A separator can be provided as first argument. Default value is newline.
+### **clipboard-paste-after**
+Paste system clipboard after selections.
+### **clipboard-paste-before**
+Paste system clipboard before selections.
+### **clipboard-paste-replace**
+Replace selections with content of system clipboard.
+### **primary-clipboard-paste-after**
+Paste primary clipboard after selections.
+### **primary-clipboard-paste-before**
+Paste primary clipboard before selections.
+### **primary-clipboard-paste-replace**
+Replace selections with content of system primary clipboard.
+### **show-clipboard-provider**
+Show clipboard provider name in status bar.
+### **change-current-directory**
+Change the current working directory.
+### **show-directory-stack**
+Show the directory stack as a <space> delimited string.
+### **push-directory**
+Save and then change the current directory.
+### **pop-directory**
+Remove the top entry from the directory stack, and cd to the new top directory..
+### **show-directory**
+Show the current working directory.
+### **encoding**
+Set encoding. Based on `https://encoding.spec.whatwg.org`.
+### **character-info**
+Get info about the character under the primary cursor.
+### **reload**
+Discard changes and reload from the source file.
+### **reload-all**
+Discard changes and reload all documents from the source files.
+### **update**
+Write changes only if the file has been modified.
+### **lsp-workspace-command**
+Open workspace command picker
+### **lsp-restart**
+Restarts the given language servers, or all language servers that are used by the current file if no arguments are supplied
+### **lsp-stop**
+Stops the given language servers, or all language servers that are used by the current file if no arguments are supplied
+### **tree-sitter-scopes**
+Display tree sitter scopes, primarily for theming and development.
+### **tree-sitter-highlight-name**
+Display name of tree-sitter highlight scope under the cursor.
+### **tree-sitter-layers**
+Display language names of tree-sitter injection layers under the cursor.
+### **debug-start**
+Start a debug session from a given template with given parameters.
+### **debug-remote**
+Connect to a debug adapter by TCP address and start a debugging session from a given template with given parameters.
+### **debug-eval**
+Evaluate expression in current debug context.
+### **vsplit**
+Open the file in a vertical split.
+### **vsplit-new**
+Open a scratch buffer in a vertical split.
+### **hsplit**
+Open the file in a horizontal split.
+### **hsplit-new**
+Open a scratch buffer in a horizontal split.
+### **tutor**
+Open the tutorial.
+### **goto**
+Goto line number.
+### **set-language**
+Set the language of current buffer (show current language if no value specified).
+### **set-option**
+Set a config option at runtime.
+For example to disable smart case search, use `:set search.smart-case false`.
+### **toggle-option**
+Toggle a config option at runtime.
+For example to toggle smart case search, use `:toggle search.smart-case`.
+### **get-option**
+Get the current value of a config option.
+### **sort**
+Sort ranges in selection.
+### **reflow**
+Hard-wrap the current selection of lines to a given width.
+### **tree-sitter-subtree**
+Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries.
+### **config-reload**
+Refresh user config.
+### **config-open**
+Open the user config.toml file.
+### **config-open-workspace**
+Open the workspace config.toml file.
+### **log-open**
+Open the helix log file.
+### **insert-output**
+Run shell command, inserting output before each selection.
+### **append-output**
+Run shell command, appending output after each selection.
+### **pipe**
+Pipe each selection to the shell command.
+### **pipe-to**
+Pipe each selection to the shell command, ignoring output.
+### **run-shell-command**
+Run a shell command
+### **reset-diff-change**
+Reset the diff change at the cursor position.
+### **clear-register**
+Clear given register. If no argument is provided, clear all registers.
+### **set-register**
+Set contents of the given register.
+### **redraw**
+Clear and re-render the whole UI
+### **move**
+Move the current buffer and its corresponding file to a different path
+### **move!**
+Move the current buffer and its corresponding file to a different path creating necessary subdirectories
+### **yank-diagnostic**
+Yank diagnostic(s) under primary cursor to register, or clipboard by default
+### **read**
+Load a file into buffer
+### **echo**
+Prints the given arguments to the statusline.
+### **noop**
+Does nothing.
+### **workspace-trust**
+Allow language servers and local config for the current workspace.
+### **workspace-untrust**
+Revoke the current workspace's trust grant or exclusion.
+### **workspace-exclude**
+Mark the current workspace as never-prompt. Never prompts for trust again.
+# /home/roastbeefer/.local/share/steel/cogs/helix/treesitter.scm
+### **TSTree?**
+Check if the given value is a treesitter tree
+### **TSNode?**
+Check if the given value is a treesitter node
+### **TSQueryLoader?**
+Check if the given value is a treesitter query loader
+### **TSSyntax?**
+Check if the given value is a treesitter query loader
+### **TSQuery?**
+Check if the given value is a treesitter query
+### **TSMatch?**
+Check if the given value is a treesitter match
+### **tsquery-loader**
+Create a query loader with the given function
+
+```scheme
+(tsquery-loader fun) -> TSQueryLoader?
+```
+
+* fun : (-> string?) -> (or TSQuery? bool?)
+### **tstree->root**
+Get the root node of the TreeSitter Tree
+
+```scheme
+(tstree->root tree) -> TSNode?
+```
+
+* tree : TSTree?
+### **tsnode->tstree**
+Get the root tree object from the given node
+```scheme
+(tsnode->tstree node) -> TSTree?
+```
+
+* node : TSNode?
+### **tsnode-parent**
+Get the root node of the TreeSitter Tree, returns #f if there is no parent
+```scheme
+(tsnode-parent node) -> (or TSNode? bool?)
+```
+
+* node : TSNode?
+### **tsnode-children**
+Get the given node's children
+```scheme
+(tsnode-children node) -> (listof TSNode?)
+```
+
+* node : TSNode?
+### **tsnode-named-children**
+Get the given node's (named) children
+```scheme
+(tsnode-named-children node) -> (listof TSNode?)
+```
+
+* node : TSNode?
+### **tsnode-within-byte-range?**
+Return whether or not the given node is within the byte range
+```scheme
+(tsnode-within-byte-range node lower upper) -> bool?
+```
+
+* node : TSNode?
+* lower : (and positive? int?)
+* upper : (and positive? int?)
+### **tsnode-descendant-byte-range**
+Return a descendant node with the largest byte range within the given range on the tree (#f if one doesn't exist)
+```scheme
+(tsnode-descendant-byte-range node lower upper) -> (or TSNode? bool?)
+```
+
+* node : TSNode?
+* lower : (and positive? int?)
+* upper : (and positive? int?)
+### **tsnode-named-descendant-byte-range**
+Return a (named) descendant node with the largest byte range within the given range on the tree (#f if one doesn't exist)
+```scheme
+(tsnode-named-descendant-byte-range node lower upper) -> (or TSNode? bool?)
+```
+
+* node : TSNode?
+* lower : (and positive? int?)
+* upper : (and positive? int?)
+### **tsnode-kind**
+Get the `kind` of a given node as a string
+```scheme
+(tsnode-kind node) -> string?
+```
+
+* node : TSNode?
+### **tsnode-named?**
+Returns whether or not the given node is named
+```scheme
+(tsnode-named? node) -> bool?
+```
+
+* node : TSNode?
+### **tsnode-extra?**
+Returns whether or not the given node is extra
+```scheme
+(tsnode-extra? node) -> bool?
+```
+
+* node : TSNode?
+### **tsnode-missing?**
+Returns whether or not the given node is missing
+```scheme
+(tsnode-missing? node) -> bool?
+```
+
+* node : TSNode?
+### **tsnode-visible?**
+Returns whether or not the given node is visible
+```scheme
+(tsnode-visible? node) -> bool?
+```
+
+* node : TSNode?
+### **tsnode-print-tree**
+Pretty print the given TSNode's subtree
+```scheme
+(tsnode-print-tree node) -> string?
+```
+
+* node : TSNode?
+### **tsnode-end-byte**
+Get the end byte idx of the TSNode's range
+```scheme
+(tsnode-end-byte node) -> (and positive? int?)
+```
+
+* node : TSNode?
+### **tsnode-start-byte**
+Get the start byte idx of the TSNode's range
+```scheme
+(tsnode-start-byte node) -> (and positive? int?)
+```
+
+* node : TSNode?
+### **tsmatch-captures**
+Get a list of captures
+```scheme
+(tsmatch-captures match) -> (listof string?)
+```
+
+* match : TSMatch?
+### **tsmatch-capture**
+Get a list of captures from the given capture group
+```scheme
+(tsmatch-capture match capture) -> (or (listof TSNode?) bool?)
+```
+
+* match : TSMatch?
+* capture : string?
+### **tssyntax->tree-byte-range**
+Get the subtree from the given byte range and TSSyntax (#f if no tree is found/available)
+```scheme
+(tssyntax->tree-byte-range syntax lower upper) -> (or TSTree? bool?)
+```
+
+* syntax : TSSyntax?
+* lower : (and positive? int?)
+* upper : (and positive? int?)
+### **tssyntax->layers-byte-range**
+Get the corresponding parse trees/layers that contain the given byte range
+```scheme
+(tssyntax->layers-byte-range syntax lower upper) -> (or (listof TSTree?) bool?)
+```
+* syntax : TSSyntax?
+* lower : (and int? positive?)
+* upper : (and int? positive?)
+### **tssyntax->tree**
+Get the root subtree from the given TSSyntax
+```scheme
+(tssyntax->tree syntax) -> TSTree?
+```
+
+* syntax : TSSyntax?
+### **document->tree**
+
+### **document->tree-byte-range**
+Get the full treesitter tree with a byte range from the given document (not necessarily the full parse tree)
+```scheme
+(document->tree-byte-range doc-id lower upper) -> (or TSTree? bool?)
+```
+* doc-id : DocumentId?
+* lower : (and int? positive?)
+* upper : (and int? positive?)
+### **document->layers-byte-range**
+Get the corresponding parse trees/layers that contain the given byte range
+```scheme
+(document->layers-byte-range doc-id lower upper) -> (listof TSTree?)
+```
+* doc-id : DocumentId?
+* lower : (and int? positive?)
+* upper : (and int? positive?)
+### **tstree->language**
+Get the language as a string from a given TSTree
+```scheme
+(tstree->language tree) -> string?
+```
+* tree : TSTree?
+### **query-document**
+Run a treesitter query on a given document's parse tree
+```scheme
+(query-document query-loader doc-id) -> (or TSMatch? bool?)
+```
+* query-loader : TSQueryLoader?
+* doc-id : DocumentId?
+### **query-document-byte-range**
+Run a treesitter query on a given document's parse tree with a range (byte indices)
+```scheme
+(query-document-byte-range query-loader doc-id lower upper) -> (or TSMatch? bool?)
+```
+* query-loader : TSQueryLoader?
+* doc-id : DocumentId?
+* lower : (and int? positive?)
+* upper : (and int? positive?)
+### **string->tsquery**
+Create a new treesitter query given a language name and source
+```scheme
+(string->tsquery lang-name query_src) -> (or TSQuery? bool?)
+```
+* lang-name : string?
+* query_src : string?
+### **query-tssyntax-byte-range**
+Run a query on the given TSSyntax parse tree with a byte range
+```scheme
+(query-tssyntax-byte-range query-loader syntax text lower upper) -> TSMatch?
+```
+* query-loader : TSQueryLoader?
+* syntax : TSSyntax?
+* text : Rope?
+* lower : (and int? positive?)
+* upper : (and int? positive?)
+### **query-tssyntax**
+Run a treesitter query on a given document's parse tree
+```scheme
+(query-tssyntax query-loader syntax text) -> TSMatch?
+```
+* query : TSQueryLoader?
+* syntax : TSSyntax?
+* text : Rope?
+### **rope->tssyntax**
+Parse the syntax tree from given a language name and source
+```scheme
+(rope->tssyntax src lang) -> (or TSQuery? bool?)
+```
+* src : Rope?
+* lang : string?
+# /home/roastbeefer/.local/share/steel/cogs/helix/configuration.scm
+### **statusline**
+Configuration of the statusline elements.
+The following status line elements can be configured:
+
+Key	                        Description
+-------------------------------------------------------------------------------------------
+mode	                        The current editor mode (mode.normal/mode.insert/mode.select)
+spinner	                    A progress spinner indicating LSP activity
+file-name	                The path/name of the opened file
+file-absolute-path	        The absolute path/name of the opened file
+file-base-name	            The basename of the opened file
+file-modification-indicator	The indicator to show whether the file is modified (a [+] appears when there are unsaved changes)
+file-encoding	            The encoding of the opened file if it differs from UTF-8
+file-line-ending	            The file line endings (CRLF or LF)
+file-indent-style	        The file indentation style
+read-only-indicator	        An indicator that shows [readonly] when a file cannot be written
+total-line-numbers	        The total line numbers of the opened file
+file-type	                The type of the opened file
+diagnostics	                The number of warnings and/or errors
+workspace-diagnostics	    The number of warnings and/or errors on workspace
+selections	                The primary selection index out of the number of active selections
+primary-selection-length	    The number of characters currently in primary selection
+position	                    The cursor position
+position-percentage	        The cursor position as a percentage of the total number of lines
+separator	                The string defined in editor.statusline.separator (defaults to "│")
+spacer	                    Inserts a space between elements (multiple/contiguous spacers may be specified)
+version-control	            The current branch name or detached commit hash of the opened workspace
+register	                    The current selected register
+### **indent-heuristic**
+Which indent heuristic to use when a new line is inserted
+Defaults to `"hybrid"`
+Valid options are:
+* "simple"
+* "tree-sitter"
+* "hybrid"
+### **atomic-save**
+Whether to use atomic operations to write documents to disk.
+This prevents data loss if the editor is interrupted while writing the file, but may
+confuse some file watching/hot reloading programs. Defaults to `#true`.
+### **lsp**
+Blanket LSP configuration
+The options are provided in a hashmap, and provided options will be merged
+with the defaults. The options are as follows:
+
+Enables LSP
+* enable: bool
+
+Display LSP messagess from $/progress below statusline
+* display-progress-messages: bool
+
+Display LSP messages from window/showMessage below statusline
+* display-messages: bool
+
+Enable automatic pop up of signature help (parameter hints)
+* auto-signature-help: bool
+
+Display docs under signature help popup
+* display-signature-help-docs: bool
+
+Display inlay hints
+* display-inlay-hints: bool
+
+Maximum displayed length of inlay hints (excluding the added trailing `…`).
+If it's `None`, there's no limit
+* inlay-hints-length-limit: Option<NonZeroU8>
+
+Display document color swatches
+* display-color-swatches: bool
+
+Whether to enable snippet support
+* snippets: bool
+
+Whether to include declaration in the goto reference query
+* goto_reference_include_declaration: bool
+
+```scheme
+(lsp (hash 'display-inlay-hints #t))
+```
+
+The defaults shown from the rust side are as follows:
+```rust
+        LspConfig {
+           enable: true,
+           display_progress_messages: false,
+           display_messages: true,
+           auto_signature_help: true,
+           display_signature_help_docs: true,
+           display_inlay_hints: false,
+           inlay_hints_length_limit: None,
+           snippets: true,
+           goto_reference_include_declaration: true,
+           display_color_swatches: true,
+       }
+
+```
+### **search**
+Search configuration
+Accepts two keywords, #:smart-case and #:wrap-around, both default to true.
+
+```scheme
+(search #:smart-case #t #:wrap-around #t)
+(search #:smart-case #f #:wrap-around #f)
+```
+### **auto-pairs**
+Automatic insertion of pairs to parentheses, brackets,
+etc. Optionally, this can be a list of pairs to specify a
+global list of characters to pair, or a hashmap of character to character.
+Defaults to true.
+
+```scheme
+(auto-pairs #f)
+(auto-pairs #t)
+(auto-pairs (list '(#\{ . #\})))
+(auto-pairs (list '(#\{ #\})))
+(auto-pairs (list (cons #\{ #\})))
+(auto-pairs (hash #\{ #\}))
+```
+### **continue-comments**
+Whether comments should be continued.
+### **popup-border**
+Set the popup border.
+Valid options are:
+* "none"
+* "all"
+* "popup"
+* "menu"
+### **register-lsp-notification-handler**
+Register a callback to be called on LSP notifications sent from the server -> client
+that aren't currently handled by Helix as a built in.
+
+```scheme
+(register-lsp-notification-handler lsp-name event-name handler)
+```
+
+* lsp-name : string?
+* event-name : string?
+* function : (-> hash? any?) ;; Function where the first argument is the parameters
+
+# Examples
+```
+(register-lsp-notification-handler "dart"
+                                   "dart/textDocument/publishClosingLabels"
+                                   (lambda (args) (displayln args)))
+```
+### **register-lsp-call-handler**
+Register a callback to be called on LSP calls sent from the server -> client
+that aren't currently handled by Helix as a built in.
+
+```scheme
+(register-lsp-call-handler lsp-name event-name handler)
+```
+
+* lsp-name : string?
+* event-name : string?
+* function : (-> hash? any?) ;; Function where the first argument is the parameters
+
+# Examples
+```
+(register-lsp-call-handler "dart"
+                                   "dart/textDocument/publishClosingLabels"
+                                   (lambda (call-id args) (displayln args)))
+```
+### **define-lsp**
+Syntax:
+
+Registers an lsp configuration. This is a thin wrapper around passing
+a hashmap manually to `set-lsp-config!`, and has a slightly more elegant
+API.
+
+Examples:
+```scheme
+(define-lsp "steel-language-server" (command steel-language-server) (args '()))
+(define-lsp "rust-analyzer" (config (experimental (hash 'testExplorer #t 'runnables '("cargo")))))
+(define-lsp "tinymist" (config (exportPdf "onType") (outputPath "$root/$dir/$name")))
+```
+### **cursor-shape**
+Shape for cursor in each mode
+
+(cursor-shape #:normal (normal 'block)
+              #:select (select 'block)
+              #:insert (insert 'block))
+
+# Examples
+
+```scheme
+(cursor-shape #:normal 'block #:select 'underline #:insert 'bar)
+```
+### **get-lsp-config**
+Get the lsp configuration for a language server.
+
+Returns a hashmap which can be passed to `set-lsp-config!`
+### **set-lsp-config!**
+Sets the language server config for a specific language server.
+
+```scheme
+(set-lsp-config! lsp config)
+```
+* lsp : string?
+* config: hash?
+
+This will overlay the existing configuration, much like the existing
+toml definition does.
+
+Available options for the config hash are:
+```scheme
+(hash "command" "<command>"
+      "args" (list "args" ...)
+      "environment" (hash "ENV" "VAR" ...)
+      "config" (hash ...)
+      "timeout" 100 ;; number
+      "required-root-patterns" (listof "pattern" ...))
+
+```
+
+# Examples
+```
+(set-lsp-config! "jdtls"
+   (hash "args" (list "-data" "/home/matt/code/java-scratch/workspace")))
+```
+### **file-picker-kw**
+Sets the configuration for the file picker using keywords.
+
+```scheme
+(file-picker-kw #:hidden #t
+                #:follow-symlinks #t
+                #:deduplicate-links #t
+                #:parents #t
+                #:ignore #t
+                #:git-ignore #t
+                #:git-exclude #t
+                #:git-global #t
+                #:max-depth #f) ;; Expects either #f or an int?
+```
+By default, max depth is `#f` while everything else is an int?
+
+To use this, call this in your `init.scm` or `helix.scm`:
+
+# Examples
+```scheme
+(file-picker-kw #:hidden #f)
+```
+### **file-picker**
+Sets the configuration for the file picker using var args.
+
+```scheme
+(file-picker . args)
+```
+
+The args are expected to be something of the value:
+```scheme
+(-> FilePickerConfiguration? bool?)
+```
+
+These other functions in this module which follow this behavior are all
+prefixed `fp-`, and include:
+
+* fp-hidden
+* fp-follow-symlinks
+* fp-deduplicate-links
+* fp-parents
+* fp-ignore
+* fp-git-ignore
+* fp-git-global
+* fp-git-exclude
+* fp-max-depth
+
+By default, max depth is `#f` while everything else is an int?
+
+To use this, call this in your `init.scm` or `helix.scm`:
+
+# Examples
+```scheme
+(file-picker (fp-hidden #f) (fp-parents #f))
+```
+### **soft-wrap-kw**
+Sets the configuration for soft wrap using keyword args.
+
+```scheme
+(soft-wrap-kw #:enable #f
+              #:max-wrap 20
+              #:max-indent-retain 40
+              #:wrap-indicator "↪"
+              #:wrap-at-text-width #f)
+```
+
+The options are as follows:
+
+* #:enable:
+  Soft wrap lines that exceed viewport width. Default to off
+* #:max-wrap:
+  Maximum space left free at the end of the line.
+  This space is used to wrap text at word boundaries. If that is not possible within this limit
+  the word is simply split at the end of the line.
+
+  This is automatically hard-limited to a quarter of the viewport to ensure correct display on small views.
+
+  Default to 20
+* #:max-indent-retain
+  Maximum number of indentation that can be carried over from the previous line when softwrapping.
+  If a line is indented further then this limit it is rendered at the start of the viewport instead.
+
+  This is automatically hard-limited to a quarter of the viewport to ensure correct display on small views.
+
+  Default to 40
+* #:wrap-indicator
+  Indicator placed at the beginning of softwrapped lines
+
+  Defaults to ↪
+* #:wrap-at-text-width
+  Softwrap at `text_width` instead of viewport width if it is shorter
+
+# Examples
+```scheme
+(soft-wrap-kw #:sw-enable #t)
+```
+### **soft-wrap**
+Sets the configuration for soft wrap using var args.
+
+```scheme
+(soft-wrap . args)
+```
+
+The args are expected to be something of the value:
+```scheme
+(-> SoftWrapConfiguration? bool?)
+```
+The options are as follows:
+
+* sw-enable:
+  Soft wrap lines that exceed viewport width. Default to off
+* sw-max-wrap:
+  Maximum space left free at the end of the line.
+  This space is used to wrap text at word boundaries. If that is not possible within this limit
+  the word is simply split at the end of the line.
+
+  This is automatically hard-limited to a quarter of the viewport to ensure correct display on small views.
+
+  Default to 20
+* sw-max-indent-retain
+  Maximum number of indentation that can be carried over from the previous line when softwrapping.
+  If a line is indented further then this limit it is rendered at the start of the viewport instead.
+
+  This is automatically hard-limited to a quarter of the viewport to ensure correct display on small views.
+
+  Default to 40
+* sw-wrap-indicator
+  Indicator placed at the beginning of softwrapped lines
+
+  Defaults to ↪
+* sw-wrap-at-text-width
+  Softwrap at `text_width` instead of viewport width if it is shorter
+
+# Examples
+```scheme
+(soft-wrap (sw-enable #t))
+```
+### **whitespace**
+Sets the configuration for whitespace using var args.
+
+```scheme
+(whitespace . args)
+```
+
+The args are expected to be something of the value:
+```scheme
+(-> WhitespaceConfiguration? bool?)
+```
+The options are as follows:
+
+* ws-visible:
+  Show all visible whitespace, defaults to false
+* ws-render:
+  manually disable or enable characters
+  render options (specified in hashmap):
+```scheme
+  (hash
+    'space #f
+    'nbsp #f
+    'nnbsp #f
+    'tab #f
+    'newline #f)
+```
+* ws-chars:
+  manually set visible whitespace characters with a hashmap
+  character options (specified in hashmap):
+```scheme
+  (hash
+    'space #\·
+    'nbsp #\⍽
+    'nnbsp #\␣
+    'tab #\→
+    'newline #\⏎
+    ; Tabs will look like "→···" (depending on tab width)
+    'tabpad #\·)
+```
+# Examples
+```scheme
+(whitespace (ws-visible #t) (ws-chars (hash 'space #\·)) (ws-render (hash 'tab #f)))
+```
+### **indent-guides**
+Sets the configuration for indent-guides using args
+
+```scheme
+(indent-guides . args)
+```
+
+The args are expected to be something of the value:
+```scheme
+(-> IndentGuidesConfig? bool?)
+```
+The options are as follows:
+
+* ig-render:
+  Show indent guides, defaults to false
+* ig-character:
+  character used for indent guides, defaults to "╎"
+* ig-skip-levels:
+  amount of levels to skip, defaults to 1
+
+# Examples
+```scheme
+(indent-guides (ig-render #t) (ig-character #\|) (ig-skip-levels 1))
+```
+### **scrolloff**
+Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
+### **scroll_lines**
+Number of lines to scroll at once. Defaults to 3
+### **mouse**
+Mouse support. Defaults to true.
+### **shell**
+Shell to use for shell commands. Defaults to ["cmd", "/C"] on Windows and ["sh", "-c"] otherwise.
+### **jump-label-alphabet**
+The characters that are used to generate two character jump labels.
+Characters at the start of the alphabet are used first. Defaults to "abcdefghijklmnopqrstuvwxyz"
+### **line-number**
+Line number mode. Defaults to 'absolute, set to 'relative for relative line numbers
+### **cursorline**
+Highlight the lines cursors are currently on. Defaults to false
+### **cursorcolumn**
+Highlight the columns cursors are currently on. Defaults to false
+### **middle-click-paste**
+Middle click paste support. Defaults to true
+### **auto-completion**
+Automatic auto-completion, automatically pop up without user trigger. Defaults to true.
+### **auto-format**
+Automatic formatting on save. Defaults to true
+### **auto-save**
+Automatic save on focus lost and/or after delay.
+Time delay in milliseconds since last edit after which auto save timer triggers.
+Time delay defaults to false with 3000ms delay. Focus lost defaults to false.
+### **auto-save-after-delay-enable**
+Enables auto save after delay. Default is false.
+### **text-width**
+Set a global text_width
+### **idle-timeout**
+Time in milliseconds since last keypress before idle timers trigger.
+Used for various UI timeouts. Defaults to 250ms.
+### **completion-timeout**
+Time in milliseconds after typing a word character before auto completions
+are shown, set to 5 for instant. Defaults to 250ms.
+### **preview-completion-insert**
+Whether to insert the completion suggestion on hover. Defaults to true.
+### **completion-trigger-len**
+Length to trigger completions
+### **completion-replace**
+Whether to instruct the LSP to replace the entire word when applying a
+completion or to only insert new text
+### **auto-info**
+Whether to display infoboxes. Defaults to true.
+### **true-color**
+Set to `true` to override automatic detection of terminal truecolor support in the event of a
+false negative. Defaults to `false`.
+### **insert-final-newline**
+Whether to automatically insert a trailing line-ending on write if missing. Defaults to `true`
+### **color-modes**
+Whether to color modes with different colors. Defaults to `false`.
+### **gutters**
+Gutter configuration
+### **undercurl**
+Set to `true` to override automatic detection of terminal undercurl support in the
+event of a false negative. Defaults to `false`.
+### **terminal**
+Terminal config
+### **rulers**
+Column numbers at which to draw the rulers. Defaults to `[]`, meaning no rulers
+### **bufferline**
+Persistently display open buffers along the top
+### **workspace-lsp-roots**
+Workspace specific lsp ceiling dirs
+### **default-line-ending**
+Which line ending to choose for new documents.
+Defaults to `native`. i.e. `crlf` on Windows, otherwise `lf`.
+### **smart-tab**
+Enables smart tab
+### **rainbow-brackets**
+Enables rainbow brackets
+### **set-keybindings!**
+Override the global keybindings with the provided keymap
+### **inline-diagnostics-cursor-line-enable**
+Inline diagnostics cursor line
+### **inline-diagnostics-other-lines-disable**
+Disable inline diagnostics for other lines
+### **inline-diagnostics-cursor-line-disable**
+Disable inline diagnostics for the cursor line
+### **inline-diagnostics-end-of-line-disable**
+Disable inline diagnostics for the end of the line
+### **inline-diagnostics-other-lines-enable**
+Inline diagnostics other lines
+### **inline-diagnostics-end-of-line-enable**
+Inline diagnostics end of line
+### **inline-diagnostics-min-diagnostics-width**
+Inline diagnostics min diagnostics width
+### **inline-diagnostics-prefix-len**
+Inline diagnostics prefix length
+### **inline-diagnostics-max-wrap**
+Inline diagnostics maximum wrap
+### **inline-diagnostics-max-diagnostics**
+Inline diagnostics max diagnostics
+### **get-language-config**
+Get the configuration for a specific language
+### **set-language-config!**
+Set the language configuration
+# /home/roastbeefer/.local/share/steel/cogs/helix/misc.scm
+### **hx.cx->pos**
+DEPRECATED: Please use `cursor-position`
+### **cursor-position**
+Returns the cursor position within the current buffer as an integer
+### **get-active-lsp-clients**
+Get all language servers, that are attached to the current buffer
+### **mode-switch-old**
+Return the old mode from the event payload
+### **mode-switch-new**
+Return the new mode from the event payload
+### **lsp-client-initialized?**
+Return if the lsp client is initialized
+### **lsp-client-name**
+Get the name of the lsp client
+### **lsp-client-offset-encoding**
+Get the offset encoding of the lsp client
+### **hx.custom-insert-newline**
+DEPRECATED: Please use `insert-newline-hook`
+### **insert-newline-hook**
+Inserts a new line with the provided indentation.
+
+```scheme
+(insert-newline-hook indent-string)
+```
+
+indent-string : string?
+
+### **push-component!**
+
+Push a component on to the top of the stack.
+
+```scheme
+(push-component! component)
+```
+
+component : WrappedDynComponent?
+
+### **pop-last-component!**
+DEPRECATED: Please use `pop-last-component-by-name!`
+### **pop-last-component-by-name!**
+Pops the last component off of the stack by name. In other words,
+it removes the component matching this name from the stack.
+
+```scheme
+(pop-last-component-by-name! name)
+```
+
+name : string?
+
+### **on-key-callback**
+
+Enqueue a function to be run on the next keypress. The function must accept
+a key event as an argument. This currently will only will work if the command is
+called via a keybinding.
+
+### **trigger-on-key-callback**
+
+Trigger an on key callback if it exists with the specified key event.
+
+### **enqueue-thread-local-callback**
+
+Enqueue a function to be run following this context of execution. This could
+be useful for yielding back to the editor in the event you want updates to happen
+before your function is run.
+
+```scheme
+(enqueue-thread-local-callback callback)
+```
+
+callback : (-> any?)
+   Function with no arguments.
+
+# Examples
+
+```scheme
+(enqueue-thread-local-callback (lambda () (theme "focus_nova")))
+```
+
+### **set-status!**
+Sets the content of the status line, with the info severity
+### **set-warning!**
+Sets the content of the status line, with the warning severity
+### **set-error!**
+Sets the content of the status line, with the error severity
+### **send-lsp-command**
+Send an lsp command. The `lsp-name` must correspond to an active lsp.
+The method name corresponds to the method name that you'd expect to see
+with the lsp, and the params can be passed as a hash table. The callback
+provided will be called with whatever result is returned from the LSP,
+deserialized from json to a steel value.
+
+```scheme
+(send-lsp-command lsp-name method-name params callback)
+```
+
+# Example
+```scheme
+(define (view-crate-graph)
+  (send-lsp-command "rust-analyzer"
+                    "rust-analyzer/viewCrateGraph"
+                    (hash "full" #f)
+                    ;; Callback to run with the result
+                    (lambda (result) (displayln result))))
+```
+### **send-lsp-notification**
+Send an LSP notification. The `lsp-name` must correspond to an active LSP.
+The method name corresponds to the method name that you'd expect to see
+with the LSP, and the params can be passed as a hash table. Unlike
+`send-lsp-command`, this does not expect a response and is used for
+fire-and-forget notifications.
+
+```scheme
+(send-lsp-notification lsp-name method-name params)
+```
+
+# Example
+```scheme
+(send-lsp-notification "copilot"
+                       "textDocument/didShowCompletion"
+                       (hash "item"
+                             (hash "insertText" "a helpful suggestion"
+                                   "range" (hash "start" (hash "line" 1 "character" 0)
+                                                 "end" (hash "line" 1 "character" 2)))))
+```
+### **lsp-reply-ok**
+Send a successful reply to an LSP request with the given result.
+
+```scheme
+(lsp-reply-ok lsp-name request-id result)
+```
+
+* lsp-name : string? - Name of the language server
+* request-id : string? - ID of the request to respond to
+* result : any? - The result value to send back
+
+# Examples
+```scheme
+;; Reply to a request with id "123" from rust-analyzer
+(lsp-reply-ok "rust-analyzer" "123" (hash "result" "value"))
+```
+### **acquire-context-lock**
+
+Schedule a function to run on the main thread. This is a fairly low level function, and odds are
+you'll want to use some abstractions on top of this.
+
+The provided function will get enqueued to run on the main thread, and during the duration of the functions
+execution, the provided mutex will be locked.
+
+```scheme
+(acquire-context-lock callback-fn mutex)
+```
+
+callback-fn : (-> void?)
+   Function with no arguments
+
+mutex : mutex?
+### **enqueue-thread-local-callback-with-delay**
+
+Enqueue a function to be run following this context of execution, after a delay. This could
+be useful for yielding back to the editor in the event you want updates to happen
+before your function is run.
+
+```scheme
+(enqueue-thread-local-callback-with-delay delay callback)
+```
+
+delay : int?
+   Time to delay the callback by in milliseconds
+
+callback : (-> any?)
+   Function with no arguments.
+
+# Examples
+
+```scheme
+(enqueue-thread-local-callback-with-delay 1000 (lambda () (theme "focus_nova"))) ;; Run after 1 second
+``
+
+### **helix-await-callback**
+DEPRECATED: Please use `await-callback`
+### **await-callback**
+
+Await the given value, and call the callback function on once the future is completed.
+
+```scheme
+(await-callback future callback)
+```
+
+* future : future?
+* callback (-> any?)
+   Function with no arguments
+### **add-inlay-hint**
+
+Warning: this is experimental
+
+Adds an inlay hint at the given character index. Returns the (first-line, last-line) list
+associated with this snapshot of the inlay hints. Use this pair of line numbers to invalidate
+the inlay hints.
+
+```scheme
+(add-inlay-hint char-index completion) -> (list int? int?)
+```
+
+char-index : int?
+completion : string?
+
+### **remove-inlay-hint**
+
+Warning: this is experimental and should not be used.
+This will most likely be removed soon.
+
+Removes an inlay hint at the given character index. Note - to remove
+properly, the completion must match what was already there.
+
+```scheme
+(remove-inlay-hint char-index completion)
+```
+
+char-index : int?
+completion : string?
+
+### **remove-inlay-hint-by-id**
+
+Warning: this is experimental
+
+Removes an inlay hint by the id that was associated with the added inlay hints.
+
+```scheme
+(remove-inlay-hint first-line last-line)
+```
+
+first-line : int?
+last-line : int?
+
+### **fuzzy-match**
+Convenience function to easily fuzzy match
+on a (relatively small list of inputs). This is not recommended for building a full tui
+application that can match large numbers of matches as all matching is done on the current
+thread, effectively blocking the UI.
+```scheme
+(fuzzy-match pattern input-list) -> (list? string?)
+```
+pattern : string?
+input-list : (list? string?)
+### **steel-mode**
+Returns the active Steel mode name, or #false if no Steel mode is active.
+### **set-steel-mode!**
+Set the active Steel mode by name. The name is shown in the statusline.
+Use register-steel-mode-keymap! to bind keys for the mode.
+### **unset-steel-mode!**
+Clear the active Steel mode.
+### **register-steel-mode-keymap!**
+Register a keymap for a named Steel mode. The keymap takes priority over
+the default helix keybindings when that mode is active.
+
+```scheme
+(register-steel-mode-keymap! name keymap)
+```
+
+name : string?
+keymap : keymap?
+# /home/roastbeefer/.local/share/steel/cogs/helix/keymaps.scm
+### ***reverse-buffer-map-insert***
+Insert a value into the reverse buffer map
+### **set-global-buffer-or-extension-keymap**
+Check that the types on this map check out, otherwise we don't need to consistently do these checks
+### **query-global-keymap**
+Query the global keybindings.
+
+```scheme
+(query-global-keymap "normal" '("space" "f")) ;; => "file_picker"
+```
+### **add-global-keybinding**
+Add keybinding to the global default
+### **deep-copy-global-keybindings**
+Deep copy the global keymap
+### **keymap**
 # helix/core/text
 To use, you can include with `(require-builtin helix/core/text)`
 ### **Rope?**
@@ -3188,6 +3723,8 @@ Returns a new rope value.
 * end: (and positive? int?)
 ### **rope->string**
 Convert the given rope to a string
+### **rope-byte->char**
+Convert the byte offset into a character offset for a given rope
 ### **rope-byte->line**
 Convert the given byte offset to a line offset for a given rope
 
@@ -3200,7 +3737,7 @@ Convert the given byte offset to a line offset for a given rope
 
             
 ### **rope-char->byte**
-Convert the byte offset into a character offset for a given rope
+Convert the character offset into a byte offset for a given rope
 ### **rope-char->line**
 Convert the given character offset to a line offset for a given rope
 
@@ -3284,6 +3821,17 @@ Returns if a regex is matching on a given rope
 * regex: RopeRegex?
 * rope: Rope?
             
+### **rope-regex-positions**
+Compile `pattern` and return the char offsets of every non-empty
+match in `rope` as a flat list: (start0 end0 start1 end1 ...). An invalid
+pattern returns an empty list.
+
+```scheme
+(rope-regex-positions pattern rope) -> (listof int?)
+```
+* pattern: string?
+* rope: Rope?
+            
 ### **rope-regex-split**
 Split on the match in a given rope
 
@@ -3303,6 +3851,17 @@ Split n times on the match in a given rope, return the rest
 * regex: RopeRegex?
 * rope: Rope?
 * n: (and positive? int?)
+### **rope-remove**
+Remove the character range `[start, end)` from the rope.
+Indices are character indices. Returns a new rope.
+
+```scheme
+(rope-remove rope start end) -> Rope?
+```
+
+* rope : Rope?
+* start : (and positive? int?)
+* end : (and positive? int?)
 ### **rope-starts-with?**
 Check if the rope starts with a given pattern
 ### **rope-trim-start**


### PR DESCRIPTION
## Summary

Three related Steel scripting API additions:

### 1. Custom Steel mode API
Adds `set-steel-mode!`, `unset-steel-mode!`, `steel-mode`, and `register-steel-mode-keymap!` — allowing scripts to define named modes with their own keymaps displayed in the statusline.

### 2. LSP WorkDoneProgress hook
Exposes `WorkDoneProgress` begin/report/end notifications as a Steel hook (`lsp-progress`), enabling scripts to display LSP task progress (e.g. fidget-style overlays).

```scheme
(register-hook! 'lsp-progress
  (lambda (server-name token kind title message percentage)
    ...))
```

### 3. Script-defined document highlight ranges
Adds `selection-char-ranges`, `set-document-highlights!`, `clear-document-highlights!`, and `clear-all-document-highlights!` — allowing scripts to set arbitrary overlay highlights on the current document using theme scopes.

```scheme
;; Highlight the current selection in a custom scope
(set-document-highlights! "my-ns" (selection-char-ranges) "ui.selection")
;; Clear after a delay
(enqueue-thread-local-callback-with-delay 350
  (lambda () (clear-document-highlights! "my-ns")))
```

These are used together in [fidget.hx](https://github.com/RoastBeefer00/fidget.hx) (LSP progress overlay) and [vim.hx](https://github.com/RoastBeefer00/vim.hx) (yank flash highlight).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)