### PR TITLE
Add per document diagnostic counts

### DIFF
--- a/helix-term/src/commands/engine/steel/editor.scm
+++ b/helix-term/src/commands/engine/steel/editor.scm
@@ -293,6 +293,11 @@
 ;;Check if a document has unsaved changes
 (define editor-document-dirty? helix.editor-document-dirty?)
 
+(provide editor-document-diagnostic-counts)
+;;@doc
+;;Counts of the document's own diagnostics by severity, as (hints info warnings errors)
+(define editor-document-diagnostic-counts helix.editor-document-diagnostic-counts)
+
 (provide editor-document-reload)
 ;;@doc
 ;;Reload a document.

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -1477,6 +1477,30 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
                 cx.editor.documents.get(&doc).map(|x| x.is_modified())
             },
         )
+        // Counts of the document's own diagnostics by severity, as (hints info warnings errors).
+        // Mirrors the fold in helix-term/src/ui/statusline.rs::render_diagnostics.
+        .register_fn_with_ctx(
+            CTX,
+            "editor-document-diagnostic-counts",
+            |cx: &mut Context, doc: DocumentId| -> Option<Vec<usize>> {
+                cx.editor.documents.get(&doc).map(|document| {
+                    let counts =
+                        document
+                            .diagnostics()
+                            .iter()
+                            .fold((0, 0, 0, 0), |mut counts, diag| {
+                                match diag.severity {
+                                    Some(Severity::Hint) | None => counts.0 += 1,
+                                    Some(Severity::Info) => counts.1 += 1,
+                                    Some(Severity::Warning) => counts.2 += 1,
+                                    Some(Severity::Error) => counts.3 += 1,
+                                }
+                                counts
+                            });
+                    vec![counts.0, counts.1, counts.2, counts.3]
+                })
+            },
+        )
         .register_fn_with_ctx(
             CTX,
             "editor-document-reload",


### PR DESCRIPTION
This pr adds `editor-document-diagnostic-counts` to the steel api. It returns diagnotics count coping the logic used by the default statusline. This allows custom statusline like [moka.hx](https://github.com/Ra77a3l3-jar/moka.hx) to be able to display diagnostic info just like the normal statusline.