### PR TITLE
add theme-set-name! so a plugin can make theme changes that survive

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -1326,6 +1326,7 @@ fn load_theme_api(engine: &mut Engine, generate_sources: bool) {
         .register_fn("add-theme!", add_theme)
         .register_fn("theme-style", get_style)
         .register_fn("theme-set-style!", set_style)
+        .register_fn("theme-set-name!", set_theme_name)
         .register_fn("string->color", string_to_color)
         .register_fn_with_ctx(CTX, "get-theme", get_theme)
         .register_fn_with_ctx(CTX, "current-theme", current_theme)
@@ -1408,6 +1409,12 @@ fn get_style(theme: &SteelTheme, name: SteelString) -> helix_view::theme::Style 
 
 fn set_style(theme: &mut SteelTheme, name: String, style: helix_view::theme::Style) {
     theme.0.set(name, style)
+}
+
+// Rename a cloned theme so it registers under a fresh name. Otherwise load()
+// would shadow it with the on-disk theme of the same name.
+fn set_theme_name(theme: &mut SteelTheme, name: String) {
+    theme.0.set_name(name)
 }
 
 fn string_to_color(string: SteelString) -> Result<Color, anyhow::Error> {

--- a/helix-term/src/commands/engine/steel/themes.scm
+++ b/helix-term/src/commands/engine/steel/themes.scm
@@ -173,6 +173,7 @@
          register-theme
          theme-style
          theme-set-style!
+         theme-set-name!
          string->color
          get-theme-by-name
          current-theme


### PR DESCRIPTION
hi! 👋

was messing around with a [zen-mode plugin](https://github.com/notnmeyer/zen-mode.hx) and was trying to hide the status bar, it doesn't appear to be possible. the next best thing was a combination of blanking the status bar (already possible) and changing the status bar's bg color to match the window's bg color. the latter was missing an api.

`current-theme` already clones the live theme, but the clone keeps the same on-disk name so when you modify it and re-register, `load()` shadows it and your changes are lost.

this adds `theme-set-name!` so you can rename the clone and register it under a fresh name that survives.