### PR TITLE
steel: add support for lsp position conversion

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -669,7 +669,9 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "current-selection-object", current_selection)
         .register_fn_with_ctx(CTX, "get-helix-cwd", get_helix_cwd)
         .register_fn_with_ctx(CTX, "move-window-far-left", move_window_to_the_left)
-        .register_fn_with_ctx(CTX, "move-window-far-right", move_window_to_the_right);
+        .register_fn_with_ctx(CTX, "move-window-far-right", move_window_to_the_right)
+        .register_fn_with_ctx(CTX, "offset->lsp", offset_to_lsp)
+        .register_fn_with_ctx(CTX, "lsp->offset", lsp_to_offset);
 
     module
         .register_fn("selection->primary-index", |sel: Selection| {
@@ -4605,6 +4607,48 @@ fn current_line_character(cx: &mut Context, encoding: SteelString) -> anyhow::Re
     };
 
     Ok(doc.position(view.id, encoding).character as usize)
+}
+
+fn offset_to_lsp(
+    cx: &mut Context,
+    encoding: SteelString,
+    offset: usize,
+) -> anyhow::Result<(u32, u32)> {
+    let (_, doc) = current_ref!(cx.editor);
+
+    let encoding = match &***encoding {
+        "utf-8" => helix_lsp::OffsetEncoding::Utf8,
+        "utf-16" => helix_lsp::OffsetEncoding::Utf16,
+        "utf-32" => helix_lsp::OffsetEncoding::Utf32,
+        _ => anyhow::bail!("invalid encoding {encoding:?}"),
+    };
+
+    let lsp_pos = helix_lsp::util::pos_to_lsp_pos(doc.text(), offset, encoding);
+
+    Ok((lsp_pos.line, lsp_pos.character))
+}
+
+fn lsp_to_offset(
+    cx: &mut Context,
+    encoding: SteelString,
+    line: u32,
+    character: u32,
+) -> anyhow::Result<usize> {
+    let (_, doc) = current_ref!(cx.editor);
+
+    let encoding = match &***encoding {
+        "utf-8" => helix_lsp::OffsetEncoding::Utf8,
+        "utf-16" => helix_lsp::OffsetEncoding::Utf16,
+        "utf-32" => helix_lsp::OffsetEncoding::Utf32,
+        _ => anyhow::bail!("invalid encoding {encoding:?}"),
+    };
+
+    let offset = helix_lsp::util::lsp_pos_to_pos(
+        doc.text(),
+        helix_lsp::Position { line, character },
+        encoding,
+    )?;
+    Ok(offset)
 }
 
 fn get_selection(cx: &mut Context) -> String {

--- a/helix-term/src/commands/engine/steel/static.scm
+++ b/helix-term/src/commands/engine/steel/static.scm
@@ -94,6 +94,16 @@
 ;;Returns the current selection object
 (define current-selection-object helix.static.current-selection-object)
 
+(provide offset->lsp)
+;;@doc
+;;Converts a document offset to a LSP position
+(define offset->lsp helix.static.offset->lsp)
+
+(provide lsp->offset)
+;;@doc
+;;Converts a LSP position to a document offset
+(define lsp->offset helix.static.lsp->offset)
+
 (provide get-helix-cwd)
 ;;@doc
 ;;Returns the current working directly that helix is using


### PR DESCRIPTION
it is currently possible to get the current cursor position as a lsp `Position` with  `get-current-line-number` and `get-current-line-character`, but it is not available for arbitrary positions.

This was necessary when adding support for `ocamllsp` custom requests.
