### PR TITLE
steel: add support for lsp position conversion

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -669,7 +669,9 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "current-selection-object", current_selection)
         .register_fn_with_ctx(CTX, "get-helix-cwd", get_helix_cwd)
         .register_fn_with_ctx(CTX, "move-window-far-left", move_window_to_the_left)
-        .register_fn_with_ctx(CTX, "move-window-far-right", move_window_to_the_right);
+        .register_fn_with_ctx(CTX, "move-window-far-right", move_window_to_the_right)
+        .register_fn_with_ctx(CTX, "offset->lsp", offset_to_lsp)
+        .register_fn_with_ctx(CTX, "lsp->offset", lsp_to_offset);
 
     module
         .register_fn("selection->primary-index", |sel: Selection| {
@@ -4594,9 +4596,7 @@ fn current_column_number(cx: &mut Context) -> usize {
     .col
 }
 
-fn current_line_character(cx: &mut Context, encoding: SteelString) -> anyhow::Result<usize> {
-    let (view, doc) = current_ref!(cx.editor);
-
+fn parse_encoding(encoding: SteelString) -> anyhow::Result<helix_lsp::OffsetEncoding> {
     let encoding = match &***encoding {
         "utf-8" => helix_lsp::OffsetEncoding::Utf8,
         "utf-16" => helix_lsp::OffsetEncoding::Utf16,
@@ -4604,7 +4604,48 @@ fn current_line_character(cx: &mut Context, encoding: SteelString) -> anyhow::Re
         _ => anyhow::bail!("invalid encoding {encoding:?}"),
     };
 
+    Ok(encoding)
+}
+
+fn current_line_character(cx: &mut Context, encoding: SteelString) -> anyhow::Result<usize> {
+    let (view, doc) = current_ref!(cx.editor);
+
+    let encoding = parse_encoding(encoding)?;
+
     Ok(doc.position(view.id, encoding).character as usize)
+}
+
+fn offset_to_lsp(
+    cx: &mut Context,
+    encoding: SteelString,
+    offset: usize,
+) -> anyhow::Result<(u32, u32)> {
+    let (_, doc) = current_ref!(cx.editor);
+
+    let encoding = parse_encoding(encoding)?;
+
+    let lsp_pos = helix_lsp::util::pos_to_lsp_pos(doc.text(), offset, encoding);
+
+    Ok((lsp_pos.line, lsp_pos.character))
+}
+
+fn lsp_to_offset(
+    cx: &mut Context,
+    encoding: SteelString,
+    line: u32,
+    character: u32,
+) -> anyhow::Result<usize> {
+    let (_, doc) = current_ref!(cx.editor);
+
+    let encoding = parse_encoding(encoding)?;
+
+    let offset = helix_lsp::util::lsp_pos_to_pos(
+        doc.text(),
+        helix_lsp::Position { line, character },
+        encoding,
+    )
+    .ok_or_else(|| anyhow::anyhow!("lsp position out of bounds"))?;
+    Ok(offset)
 }
 
 fn get_selection(cx: &mut Context) -> String {

--- a/helix-term/src/commands/engine/steel/static.scm
+++ b/helix-term/src/commands/engine/steel/static.scm
@@ -94,6 +94,16 @@
 ;;Returns the current selection object
 (define current-selection-object helix.static.current-selection-object)
 
+(provide offset->lsp)
+;;@doc
+;;Converts an offset in the current document to a LSP position
+(define offset->lsp helix.static.offset->lsp)
+
+(provide lsp->offset)
+;;@doc
+;;Converts a LSP position to an offset in the current document
+(define lsp->offset helix.static.lsp->offset)
+
 (provide get-helix-cwd)
 ;;@doc
 ;;Returns the current working directly that helix is using


### PR DESCRIPTION
This exposes the conversion logic for turning a document offset into a LSP position (and the opposite conversion).
This only works for the current document.

This is required for providing eg the range of the primary selection to a language server, or navigating between positions provided by a language server.
.
Note: the exposed functions only work on the current document. It might be desirable to expose more generic functions that also take a document. There are [accompanying steel helpers](https://tangled.org/clementd.wtf/ocaml-helix/blob/main/lsp-utils.scm#L16) that retrieve the offset encoding of a given language server that could be included as well if this makes sense. If the core conversion functions are generalized to take a document, those helpers could also provide a simpler interface for converting positions in the current document.

I’m already running a fork with those functions added, so I’m not in a rush, but these come in handy when it comes to handling custom LSP commands. It might be possible to express the rope logic in steel directly, but this is common enough that i think it belongs here