### PR TITLE
steel: expose startup file args to scripting (startup-file-args)

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -135,6 +135,11 @@ impl Application {
         );
         Self::load_configured_theme(&mut editor, &config.load(), &mut terminal, theme_mode);
 
+        // Snapshot the startup file-arg paths before they're consumed below
+        // to open documents (see `Editor::startup_file_args`). Excludes
+        // `--tutor`, which isn't a path the user typed.
+        editor.startup_file_args = args.files.keys().cloned().collect();
+
         let keys = Box::new(Map::new(Arc::clone(&config), |config: &Config| {
             &config.keys
         }));

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -668,6 +668,7 @@ fn load_static_commands(engine: &mut Engine, generate_sources: bool) {
         .register_fn_with_ctx(CTX, "get-current-column-number", current_column_number)
         .register_fn_with_ctx(CTX, "current-selection-object", current_selection)
         .register_fn_with_ctx(CTX, "get-helix-cwd", get_helix_cwd)
+        .register_fn_with_ctx(CTX, "startup-file-args", startup_file_args)
         .register_fn_with_ctx(CTX, "move-window-far-left", move_window_to_the_left)
         .register_fn_with_ctx(CTX, "move-window-far-right", move_window_to_the_right);
 
@@ -5134,6 +5135,17 @@ pub fn get_helix_cwd(_cx: &mut Context) -> Option<String> {
         .as_os_str()
         .to_str()
         .map(|x| x.into())
+}
+
+// The file paths passed on the command line at startup (empty if none, e.g.
+// a bare `hx` that opens the default scratch buffer). Mirrors Neovim's
+// `argv()`.
+pub fn startup_file_args(cx: &mut Context) -> Vec<String> {
+    cx.editor
+        .startup_file_args
+        .iter()
+        .filter_map(|p| p.to_str().map(String::from))
+        .collect()
 }
 
 // Special newline...

--- a/helix-term/src/commands/engine/steel/static.scm
+++ b/helix-term/src/commands/engine/steel/static.scm
@@ -99,6 +99,13 @@
 ;;Returns the current working directly that helix is using
 (define get-helix-cwd helix.static.get-helix-cwd)
 
+(provide startup-file-args)
+;;@doc
+;;Returns the list of file paths passed on the command line at startup
+;;(empty if none, e.g. a bare `hx` that opens the default scratch buffer).
+;;Mirrors Neovim's `argv()`.
+(define startup-file-args helix.static.startup-file-args)
+
 (provide move-window-far-left)
 ;;@doc
 ;;Moves the current window to the far left

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1366,6 +1366,16 @@ pub struct Editor {
     pub editor_clipping: ClippingConfiguration,
 
     pub workspace_trust: WorkspaceTrust,
+
+    /// File paths passed on the command line at startup (empty if none, e.g.
+    /// a bare `hx` invocation that opens the default scratch buffer).
+    /// Mirrors Neovim's `argv()`. Set once in `Application::new`, before the
+    /// initialization script runs and before the paths are consumed to open
+    /// documents: opening the default scratch buffer doesn't dispatch a
+    /// document event, so this is the only point at which "no file arguments
+    /// were given" can be distinguished from every later point in the
+    /// session.
+    pub startup_file_args: Vec<PathBuf>,
 }
 
 #[derive(Default)]
@@ -1501,6 +1511,7 @@ impl Editor {
             editor_clipping: ClippingConfiguration::default(),
             dir_stack: VecDeque::with_capacity(DIR_STACK_CAP),
             workspace_trust,
+            startup_file_args: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## What
Adds `Editor::startup_file_args: Vec<PathBuf>` — the file paths passed on the command line at startup — and exposes it to Steel as `(startup-file-args)`. Mirrors Neovim's `argv()`.

Captured once in `Application::new`, before those paths are consumed to open documents. This is the only point where this is available: once the editor is running, there's no way to tell a bare `hx` apart from `hx some/file` — the default scratch buffer opened with no arguments doesn't dispatch a document event.

## Why
A concrete case: a session-restore plugin shouldn't reload a saved session when Helix is invoked as a one-off editor for a single file, e.g. `git commit`/`jj commit` opening `hx` on a commit-message path. `startup-file-args` returns the raw list rather than a pre-decided boolean, so a plugin can build whatever check it needs on top.

## Known gap
`--tutor` doesn't populate `args.files`, so it isn't reflected here. Not addressed in this PR — could be fixed separately by having `--tutor` join the normal file-arg path, the way `vimtutor` does in Vim.

## Testing
- `cargo check -p helix-term`
- Manually verified end-to-end: a Steel script calling `(startup-file-args)` returns `()` for a bare `hx` and the given path(s) for `hx <file>`.