### PR TITLE
Reload Steel buffers through known views

### DIFF
--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -1481,24 +1481,42 @@ fn load_editor_api(engine: &mut Engine, generate_sources: bool) {
             CTX,
             "editor-document-reload",
             |cx: &mut Context, doc: DocumentId| -> anyhow::Result<()> {
-                let path = cx
+                let scrolloff = cx.editor.config().scrolloff;
+                let focused_view_id = view!(cx.editor).id;
+
+                let (path, view_ids) = {
+                    let Some(x) = cx.editor.documents.get_mut(&doc) else {
+                        return Ok(());
+                    };
+
+                    let mut view_ids: Vec<_> = x.selections().keys().copied().collect();
+                    if view_ids.is_empty() {
+                        x.ensure_view_init(focused_view_id);
+                        view_ids.push(focused_view_id);
+                    }
+
+                    (x.path().map(|path| path.to_path_buf()), view_ids)
+                };
+
+                let x = doc_mut!(cx.editor, &doc);
+                let view = view_mut!(cx.editor, view_ids[0]);
+                view.sync_changes(x);
+
+                let trust_full = cx
                     .editor
-                    .documents
-                    .get(&doc)
-                    .and_then(|x| x.path().map(|x| x.to_path_buf()));
+                    .workspace_trust
+                    .query(
+                        x.workspace_root(),
+                        helix_loader::workspace_trust::TrustQuery::Git,
+                    )
+                    .is_trusted();
+                x.reload(view, &cx.editor.diff_providers, trust_full)?;
 
-                for (view, _) in cx.editor.tree.views_mut() {
-                    if let Some(x) = cx.editor.documents.get_mut(&doc) {
-                        let trust_full = cx
-                            .editor
-                            .workspace_trust
-                            .query(
-                                x.workspace_root(),
-                                helix_loader::workspace_trust::TrustQuery::Git,
-                            )
-                            .is_trusted();
-
-                        x.reload(view, &cx.editor.diff_providers, trust_full)?;
+                for view_id in view_ids {
+                    let view = view_mut!(cx.editor, view_id);
+                    if view.doc == doc {
+                        view.sync_changes(x);
+                        view.ensure_cursor_in_view(x, scrolloff);
                     }
                 }
                 if let Some(path) = path {


### PR DESCRIPTION
Steel plugins can reload a specific open buffer by its ID. That buffer may be visible in one or more panes, or remain open in the background after the user switches a pane to another file.

The previous implementation reloaded the target buffer once for every visible pane. In a split showing `a.rs` on the left and `b.rs` on the right, reloading `a.rs` first used the left pane correctly, then tried to reload `a.rs` through the right pane. The right pane has state for `b.rs`, not `a.rs`, so Helix panicked while looking up cursor and selection state.

This change follows the existing `:reload-all` [behavior](https://github.com/mattwparas/helix/blob/6b7c7c6e0784d7c34295c24064deb36418c0b4b5/helix-term/src/commands/typed.rs#L1601) for one requested buffer:

- reload through one pane the buffer already knows;
- initialize fallback state only when the buffer has no known pane;
- synchronize all panes currently displaying that buffer after reload.

This prevents the split-pane crash and keeps `editor-document-reload` usable for background buffers.
