### PR TITLE
Resolve Steel components from memory

### DIFF
--- a/helix-term/src/commands/engine/steel/components.rs
+++ b/helix-term/src/commands/engine/steel/components.rs
@@ -233,7 +233,7 @@ fn push_status_elem(
     cfg.store_config(app_config);
     Ok(())
 }
-pub fn helix_component_module(generate_sources: bool) -> BuiltInModule {
+pub fn helix_component_module(generate_sources: bool) -> (BuiltInModule, String) {
     let mut module = BuiltInModule::new("helix/components");
 
     let mut builtin_components_module = include_str!("components.scm").to_string();
@@ -764,7 +764,7 @@ event: Event?"#, $name, $name));
         configure_lsp_builtins("component", &module);
     }
 
-    module
+    (module, builtin_components_module)
 }
 
 fn buffer_set_string(

--- a/helix-term/src/commands/engine/steel/mod.rs
+++ b/helix-term/src/commands/engine/steel/mod.rs
@@ -548,7 +548,11 @@ fn add_reverse_mapping(key: usize, label: String) {
 }
 
 fn load_component_api(engine: &mut Engine, generate_sources: bool) {
-    let module = helix_component_module(generate_sources);
+    let (module, builtin_components_module) = helix_component_module(generate_sources);
+    engine.register_steel_module(
+        "helix/components.scm".to_string(),
+        builtin_components_module,
+    );
     engine.register_module(module);
 }
 


### PR DESCRIPTION
Helix registers its generated Steel wrapper modules in memory, but `helix/components.scm` was the exception. Its imports therefore fell through to the copy under `STEEL_HOME`, which every `hx` process rewrites during startup. Parallel processes could expose a partial file to `init.scm`, producing missing-identifier errors while the editor continued without its Steel configuration.

This change returns the complete generated components source and registers it with the Steel engine like the other Helix modules. Runtime imports no longer depend on the on-disk LSP copy, while existing LSP source generation remains unchanged.

The broader startup rewrite race remains in the generated LSP artifacts and is tracked in [#139](https://github.com/mattwparas/helix/issues/139).