### PR TITLE
close layers by removing themselves instead of popping the topmost layer

### DIFF
--- a/helix-term/src/commands/engine/steel/components.rs
+++ b/helix-term/src/commands/engine/steel/components.rs
@@ -941,9 +941,10 @@ impl Component for SteelDynamicComponent {
     ) -> compositor::EventResult {
         // Ignore this event off the stack
         if !is_current_generation(self.generation) {
+            let name = self.name.clone();
             return compositor::EventResult::Ignored(Some(Box::new(
-                |compositor: &mut compositor::Compositor, _| {
-                    compositor.pop();
+                move |compositor: &mut compositor::Compositor, _| {
+                    compositor.remove_topmost_matching(|layer| layer.name() == Some(&name));
                 },
             )));
         }
@@ -991,23 +992,33 @@ impl Component for SteelDynamicComponent {
                     let value = SteelEventResult::from_steelval(&v);
 
                     match value {
-                        Ok(SteelEventResult::Close) => compositor::EventResult::Consumed(Some(
-                            Box::new(|compositor: &mut compositor::Compositor, _| {
-                                // remove the layer
-                                compositor.pop();
-                            }),
-                        )),
+                        Ok(SteelEventResult::Close) => {
+                            let name = self.name.clone();
+                            compositor::EventResult::Consumed(Some(Box::new(
+                                move |compositor: &mut compositor::Compositor, _| {
+                                    // remove the layer
+                                    compositor.remove_topmost_matching(|layer| {
+                                        layer.name() == Some(&name)
+                                    });
+                                },
+                            )))
+                        }
                         Ok(SteelEventResult::Consumed) => compositor::EventResult::Consumed(None),
                         Ok(SteelEventResult::ConsumedWithoutRerender) => {
                             compositor::EventResult::ConsumedWithoutRerender
                         }
                         Ok(SteelEventResult::Ignored) => compositor::EventResult::Ignored(None),
-                        Ok(SteelEventResult::IgnoreAndClose) => compositor::EventResult::Ignored(
-                            Some(Box::new(|compositor: &mut compositor::Compositor, _| {
-                                // remove the layer
-                                compositor.pop();
-                            })),
-                        ),
+                        Ok(SteelEventResult::IgnoreAndClose) => {
+                            let name = self.name.clone();
+                            compositor::EventResult::Ignored(Some(Box::new(
+                                move |compositor: &mut compositor::Compositor, _| {
+                                    // remove the layer
+                                    compositor.remove_topmost_matching(|layer| {
+                                        layer.name() == Some(&name)
+                                    });
+                                },
+                            )))
+                        }
                         _ => compositor::EventResult::Ignored(None),
                     }
                 }

--- a/helix-term/src/compositor.rs
+++ b/helix-term/src/compositor.rs
@@ -149,6 +149,23 @@ impl Compositor {
         Some(self.layers.remove(idx))
     }
 
+    /// Remove the topmost layer matching the predicate, keeping any layers
+    /// above it in place. Closing layers use this so a layer stacked above
+    /// them is never removed in their place.
+    pub fn remove_topmost_matching(
+        &mut self,
+        predicate: impl Fn(&dyn Component) -> bool,
+    ) -> Option<Box<dyn Component>> {
+        let idx = self
+            .layers
+            .iter()
+            .rposition(|layer| predicate(layer.as_ref()))?;
+        let above: Vec<Box<dyn Component>> = self.layers.drain(idx + 1..).collect();
+        let removed = self.layers.remove(idx);
+        self.layers.extend(above);
+        Some(removed)
+    }
+
     pub fn remove_type<T: 'static>(&mut self) {
         let type_name = std::any::type_name::<T>();
         self.layers

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -243,7 +243,14 @@ impl<T: Item + 'static> Component for Menu<T> {
 
         let close_fn: Option<Callback> = Some(Box::new(|compositor: &mut Compositor, _| {
             // remove the layer
-            compositor.pop();
+            compositor.remove_topmost_matching(|layer| {
+                let tn = layer.type_name();
+                // a menu can be pushed directly, wrapped in a popup (completion,
+                // code actions), or embedded in a select, which delegates events
+                tn.starts_with("helix_term::ui::menu::Menu")
+                    || tn.starts_with("helix_term::ui::popup::Popup<helix_term::ui::menu::Menu")
+                    || tn.starts_with("helix_term::ui::select::Select")
+            });
         }));
 
         // Ignore tab key when supertab is turned on in order not to interfere

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1070,7 +1070,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                 if picker.matcher.snapshot().item_count() > 1_000_000 {
                     Box::new(|compositor: &mut Compositor, _ctx| {
                         // remove the layer
-                        compositor.pop();
+                        compositor.remove_topmost_matching(|layer| layer.id() == Some(ID));
                     })
                 } else {
                     // stop streaming in new items in the background, really we should
@@ -1080,7 +1080,8 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                     picker.version.fetch_add(1, atomic::Ordering::Relaxed);
                     Box::new(|compositor: &mut Compositor, _ctx| {
                         // remove the layer
-                        compositor.last_picker = compositor.pop();
+                        compositor.last_picker =
+                            compositor.remove_topmost_matching(|layer| layer.id() == Some(ID));
                     })
                 };
             EventResult::Consumed(Some(callback))

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -620,7 +620,9 @@ impl Component for Prompt {
 
         let close_fn = EventResult::Consumed(Some(Box::new(|compositor: &mut Compositor, _| {
             // remove the layer
-            compositor.pop();
+            compositor.remove_topmost_matching(|layer| {
+                layer.type_name() == std::any::type_name::<Prompt>()
+            });
         })));
 
         match event {


### PR DESCRIPTION
Right now in `scopeline` and `moka` use a steel component that stays on screen from startup. Closing things like the search prompt, the file picker or a menu uses compositor.pop(), which removes the top layer. So when the plugin bar happens to be on top, the pop removes the plugin component instead of the prompt or picker.

This makes so that running `hx .` with scopeline and moka required you to press enter twice to pick a file, because the first enter only removes the bar. Same when searching inside a file.
Compositor::remove_topmost_matching and makes prompts, pickers, menus and steel components remove themselves on close, instead of popping whatever is on top.

- (https://github.com/Ra77a3l3-jar/scopeline.hx/issues/4)
- (https://github.com/Ra77a3l3-jar/scopeline.hx/issues/1)