### PR TITLE
Bump flake inputs for static.crates.io crate downloads

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1788039129,
+        "narHash": "sha256-pa4Q0qErvCvzCaaUph7Sm37RhR4xvPrYI8Lgz6k85+A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "d2f67949798825fe853f7c5d0492b8bf016d3f88",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775358767,
-        "narHash": "sha256-f2eC+WIfhjevCPQILuV08i/kmKZzYZpUvkom/33VxCA=",
+        "lastModified": 1788077403,
+        "narHash": "sha256-c20YZQKzQ27qC6Wh729fWRTpI7oV4+7Ur4icKssD4Wc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "20fd44bc663daa53a2575e01293e24e681d62244",
+        "rev": "89e26eeaafa88a2ede4778734acc794ff0299beb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
       lib.mapAttrs (system: pkgs: {
         default = let
           commonRustFlagsEnv = "-C link-arg=-fuse-ld=lld -C target-cpu=native --cfg tokio_unstable";
-          platformRustFlagsEnv = lib.optionalString pkgs.stdenv.isLinux "-Clink-arg=-Wl,--no-rosegment";
+          platformRustFlagsEnv = lib.optionalString pkgs.stdenv.hostPlatform.isLinux "-Clink-arg=-Wl,--no-rosegment";
         in
           pkgs.mkShell {
             inputsFrom = [
@@ -75,8 +75,8 @@
                 rust-bin.nightly.latest.rust-analyzer
                 mdbook
               ]
-              ++ (lib.optional (stdenv.isx86_64 && stdenv.isLinux) cargo-tarpaulin)
-              ++ (lib.optional stdenv.isLinux lldb);
+              ++ (lib.optional (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isLinux) cargo-tarpaulin)
+              ++ (lib.optional stdenv.hostPlatform.isLinux lldb);
             shellHook = ''
               export RUST_BACKTRACE="1"
               export RUSTFLAGS="''${RUSTFLAGS:-""} ${commonRustFlagsEnv} ${platformRustFlagsEnv}"

--- a/grammars.nix
+++ b/grammars.nix
@@ -98,7 +98,7 @@
       '';
 
       # Strip failed on darwin: strip: error: symbols referenced by indirect symbol table entries that can't be stripped
-      fixupPhase = lib.optionalString stdenv.isLinux ''
+      fixupPhase = lib.optionalString stdenv.hostPlatform.isLinux ''
         runHook preFixup
         $STRIP $out/$SHARED_LIB
         runHook postFixup


### PR DESCRIPTION
Newer nixpkgs fetches crate tarballs from static.crates.io instead of the rate-limited crates.io API, avoiding intermittent HTTP 403s.

This flake uses rustPlatform.importCargoLock (cargoLock in default.nix), fixed in NixOS/nixpkgs#524985 (NixOS/nixpkgs#524979). Upstream: rust-lang/crates.io#13482.

Also replace deprecated stdenv.isLinux/isx86_64 with hostPlatform.